### PR TITLE
Rename and require σ kwarg and use more conservative guesses for initialization

### DIFF
--- a/bletl/growth.py
+++ b/bletl/growth.py
@@ -2,7 +2,6 @@ import logging
 import numpy
 import scipy.stats
 import typing
-import warnings
 
 import arviz
 import pymc3
@@ -247,7 +246,7 @@ def fit_mu_t(
     mcmc_samples:int=0,
     mu_prior:float=0,
     σ:float=None,
-    drift_scale:float=0.01,
+    drift_scale:float,
     nu:float=5,
     x0_prior:float=0.25,
     student_t:typing.Optional[bool]=None,
@@ -277,6 +276,7 @@ def fit_mu_t(
         Defaults to 0 which works well if there was a lag phase.
     drift_scale : float
         Standard deviation or scale of the random walk (how much µ_t drifts per timestep).
+        This controls the bias-variance tradeoff of the method.
     nu : float
         Degree of freedom for StudentT random walks.
         This controls the prior probability of switchpoints.
@@ -324,10 +324,6 @@ def fit_mu_t(
         mu_prior = numpy.array([mu_prior] + [0] * (TS - 1))
         # Override guess with user-provided mu_prior for nonzero starting points.
         mu_guess[mu_prior != 0] = mu_prior[mu_prior != 0]
-
-    if σ is not None:
-        warnings.warn("The `σ` parameter was renamed to `drift_scale`.", DeprecationWarning)
-        drift_scale = σ
 
     # build PyMC3 model
     coords = {

--- a/bletl/growth.py
+++ b/bletl/growth.py
@@ -9,8 +9,6 @@ import theano.tensor as tt
 
 import calibr8
 
-from . import splines
-
 _log = logging.getLogger(__file__)
 
 

--- a/bletl/growth.py
+++ b/bletl/growth.py
@@ -195,7 +195,7 @@ def _make_random_walk(name:str, *, mu: float=0, sigma:float, nu: float=1, length
         return pymc3.GaussianRandomWalk(name, mu=mu, sigma=sigma, shape=(length,), testval=initval)
 
 
-def _get_smoothed_mu(t: numpy.ndarray, y: numpy.ndarray, cm_cdw: calibr8.CalibrationModel, *, clip=0.8) -> numpy.ndarray:
+def _get_smoothed_mu(t: numpy.ndarray, y: numpy.ndarray, cm_cdw: calibr8.CalibrationModel, *, clip=0.5) -> numpy.ndarray:
     """Calculate a rough estimate of the specific growth rate from smoothed observations.
 
     Parameters

--- a/tests/test_growth.py
+++ b/tests/test_growth.py
@@ -148,3 +148,17 @@ class TestRandomWalkModel:
         )
         assert numpy.mean(result.mu_map - 0.42) < 0.1
         pass
+
+    def test_σ_deprecation_warning(self, biomass_curve, biomass_calibration):
+        t = numpy.arange(0, 1, 0.1)
+        X = 0.25 * numpy.exp(t * 0.42)
+        loc, scale, df = biomass_calibration.predict_dependent(X)
+        bs = scipy.stats.t.rvs(loc=loc, scale=scale, df=df)
+
+        with pytest.warns(DeprecationWarning, match="`σ` parameter was renamed"):
+            bletl.growth.fit_mu_t(
+                t=t, y=bs,
+                calibration_model=biomass_calibration,
+                σ=0.1,
+            )
+        pass

--- a/tests/test_growth.py
+++ b/tests/test_growth.py
@@ -96,6 +96,7 @@ class TestRandomWalkModel:
             t=t, y=bs,
             calibration_model=biomass_calibration,
             student_t=False,
+            drift_scale=0.01,
         )
         assert isinstance(result, bletl.growth.GrowthRateResult)
         assert len(result.mu_map) == len(t) - 1
@@ -119,7 +120,8 @@ class TestRandomWalkModel:
             t=t, y=bs,
             calibration_model=biomass_calibration,
             student_t=True,
-            mu_prior=0.4
+            mu_prior=0.4,
+            drift_scale=0.01,
         )
         assert isinstance(result, bletl.growth.GrowthRateResult)
         assert len(result.mu_map) == len(t) - 1
@@ -145,20 +147,7 @@ class TestRandomWalkModel:
             calibration_model=biomass_calibration,
             student_t=student_t,
             mu_prior=0.42,
+            drift_scale=0.01,
         )
         assert numpy.mean(result.mu_map - 0.42) < 0.1
-        pass
-
-    def test_σ_deprecation_warning(self, biomass_curve, biomass_calibration):
-        t = numpy.arange(0, 1, 0.1)
-        X = 0.25 * numpy.exp(t * 0.42)
-        loc, scale, df = biomass_calibration.predict_dependent(X)
-        bs = scipy.stats.t.rvs(loc=loc, scale=scale, df=df)
-
-        with pytest.warns(DeprecationWarning, match="`σ` parameter was renamed"):
-            bletl.growth.fit_mu_t(
-                t=t, y=bs,
-                calibration_model=biomass_calibration,
-                σ=0.1,
-            )
         pass


### PR DESCRIPTION
The guesstimation function for initial growth rate guesses clipped to the interval [-0.8, 0.8]. With Student-t random walks such extreme values can lead to the optimizer just accepting these extreme parameters and not converging reliably.
Clipping to [-0.5, 0.5] makes that a little more robust.

The σ kwarg looks cool, but is really hard to type outside of Jupyter notebooks.
I renamed it to `drift_scale` for easier typing.

Also the `drift_scale` is now required to be user-specified, because...
+ Its value must be compatible with the `dt` of the data.
+ This parameter is a key tuning know for the bias-variance tradeoff. We can't set a default, because we don't know the user's assumptions about growth rate stability.