### PR TITLE
Refactor for PyMC `4.0.0b2` compatibility of `bletl.growth`

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -1,6 +1,6 @@
 name: pipeline
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   test-job:

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -e .
-        pip install flake8 pytest pytest-cov codecov wheel calibr8 pymc3
+        pip install -r requirements-dev.txt
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -8,6 +8,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
+        pymc-version: ["without", "pymc==4.0.0b2", "pymc3"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
@@ -24,8 +25,14 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings
         flake8 . --count --exit-zero --statistics
-    - name: Test with pytest
+    - name: Test without PyMC
+      if: matrix.pymc-version == 'without'
       run: |
+        pytest --cov=./bletl --cov-report xml --cov-report term-missing tests/
+    - name: Install and test with PyMC
+      if: matrix.pymc-version != 'without'
+      run: |
+        pip install ${{ matrix.pymc-version }}
         pytest --cov=./bletl --cov-report xml --cov-report term-missing tests/
     - name: Upload coverage
       uses: codecov/codecov-action@v1

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,7 +29,6 @@ jobs:
         pytest --cov=./bletl --cov-report xml --cov-report term-missing tests/
     - name: Upload coverage
       uses: codecov/codecov-action@v1
-      if: matrix.python-version == 3.8
       with:
         file: ./coverage.xml
     - name: Test Wheel install and import

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install -e . 
-        pip install flake8 pytest pytest-cov twine wheel calibr8 pymc3
+        pip install -r requirements-dev.txt
     - name: Test with pytest
       run: |
         pytest --cov=./bletl --cov-report xml --cov-report term-missing tests/

--- a/bletl/__init__.py
+++ b/bletl/__init__.py
@@ -13,4 +13,4 @@ from . heuristics import find_do_peak
 from . splines import get_crossvalidated_spline
 
 
-__version__ = '1.0.5'
+__version__ = '1.1.0'

--- a/bletl/growth.py
+++ b/bletl/growth.py
@@ -165,8 +165,8 @@ def _make_random_walk(name:str, *, mu: float=0, sigma:float, nu: float=1, length
     For some PyMC versions and for Student-t distributed random walks,
     the distribution is created from a cumsum of a N-dimensional random variable.
 
-    Parameteres
-    -----------
+    Parameters
+    ----------
     name : str
         Name of the random walk variable.
     mu : float, array-like
@@ -216,6 +216,9 @@ def _make_random_walk(name:str, *, mu: float=0, sigma:float, nu: float=1, length
             "mu": mu,
             "sigma": sigma,
             "shape": (length,),
+            # Since the initval refers to the random walk, but we're creating it
+            # using the cumsum of an RV, we need to do numpy.diff to get an initial
+            # value for the RV from the initial value of the random walk.
             initval_kwarg: numpy.diff(initval, prepend=0) if initval is not None else None,
         }
 

--- a/bletl/growth.py
+++ b/bletl/growth.py
@@ -245,7 +245,6 @@ def fit_mu_t(
     switchpoints:typing.Optional[typing.Union[typing.Sequence[float], typing.Dict[float, str]]]=None,
     mcmc_samples:int=0,
     mu_prior:float=0,
-    σ:float=None,
     drift_scale:float,
     nu:float=5,
     x0_prior:float=0.25,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 calibr8
 codecov
 flake8
-pymc3
 pytest
 pytest-cov
 twine

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+calibr8
+codecov
+flake8
+pymc3
+pytest
+pytest-cov
+twine
+wheel

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
         zip_safe=False,
         version=__version__,
         description='Package for parsing and transforming BioLector raw data.',
-        url='https://jugit.fz-juelich.de/IBG-1/biopro/bletl',
+        url='https://github.com/jubiotech/bletl',
         author='Michael Osthege',
         author_email='m.osthege@fz-juelich.de',
         license='GNU Affero General Public License v3.0',

--- a/tests/test_growth.py
+++ b/tests/test_growth.py
@@ -6,8 +6,7 @@ import scipy.stats
 try:
     import bletl.growth
     import calibr8
-    import pymc3
-    from theano.tensor import TensorVariable
+    from calibr8.utils import at, pm
 
     HAS_DEPENDENCIES = True
 except ImportError:
@@ -52,24 +51,24 @@ def biomass_curve():
 @pytest.mark.skipif(not HAS_DEPENDENCIES, reason="Needs optional dependencies.")
 class TestGrowthHelpers:
     def test_make_gaussian_random_walk(self):
-        with pymc3.Model() as pmodel:
+        with pm.Model() as pmodel:
             rv = bletl.growth._make_random_walk(
                 "testGRW",
                 sigma=0.02,
                 length=20,
                 student_t=False,
             )
-            assert isinstance(rv, TensorVariable)
+            assert isinstance(rv, at.TensorVariable)
 
     def test_make_studentt_random_walk(self):
-        with pymc3.Model() as pmodel:
+        with pm.Model() as pmodel:
             rv = bletl.growth._make_random_walk(
                 "testSTRW",
                 sigma=0.02,
                 length=20,
                 student_t=True,
             )
-            assert isinstance(rv, TensorVariable)
+            assert isinstance(rv, at.TensorVariable)
         pass
 
     def test_get_smoothed_mu(self, biomass_curve, biomass_calibration):
@@ -86,6 +85,7 @@ class TestGrowthHelpers:
         pass
 
 
+@pytest.mark.skipif(not HAS_DEPENDENCIES, reason="Needs optional dependencies.")
 class TestRandomWalkModel:
     def test_fit_mu_t_gaussian(self, biomass_curve, biomass_calibration):
         t, X, mu_true = biomass_curve


### PR DESCRIPTION
+ Imports were refactored to be compatible with any PyMC version.
+ Creation of the random walks was refactored to account for `4.0.0b2` still missing `GaussianRandomWalk`.
+ The CI pipelines were refactored to test with a matrix of PyMC versions (similar to https://github.com/JuBiotech/murefi/pull/4).
