### PR TITLE
Add test dataset and regression test for #24

### DIFF
--- a/tests/data/BLPro/issue24.csv
+++ b/tests/data/BLPro/issue24.csv
@@ -1,0 +1,3822 @@
+=====process=====
+[process] 439
+[start_date_time] 2022-06-22, 10:19:40
+[hardware_id] B2-12-3456-7890
+[file_version_number] 0.0.0
+[internal_referencing] 1
+[hmi_version] 1.135
+[is_compressed] 1
+[referencing] 2
+[01_reference_value_Biomass] 203.582016
+[02_reference_value_Biomass] 203.582016
+[03_reference_value_pH(HP8)] 100.000000
+[04_reference_value_DO(PSt3)] 100.000000
+[05_reference_value_Fluorescence] 382.613068
+[06_reference_value_Fluorescence] 382.613068
+[01_reference_gain_Biomass] 2
+[02_reference_gain_Biomass] 2
+[05_reference_gain_Fluorescence] 2
+[06_reference_gain_Fluorescence] 2
+[03_gain_pH(HP8)] 7
+[04_gain_DO(PSt3)] 7
+=====protocol=====
+====== main ======
+[name] Error
+[final] False
+[user] abcdef
+[comment]
+[mtp] MTP_MF32-FlowerPlate
+[mtp-rows] 6
+[mtp-columns] 8
+[mtp-lot] 2117121
+[layout] DOE
+[biolection_version] 3.20.3.0-cbb6738abf31b45c3bbd654d1000ca57bfd1363b
+====== channels ======
+[no_filterset] 6
+===== measurement channels =====
+[01_no] 1
+[01_name] Biomass
+[01_filter_id] 401
+[01_filter_type] Intensity
+[01_gain_1] 1
+[01_gain_2] 1
+[01_calibration]
+===== measurement channels =====
+[02_no] 2
+[02_name] Biomass3
+[02_filter_id] 401
+[02_filter_type] Intensity
+[02_gain_1] 3
+[02_gain_2] 1
+[02_calibration]
+===== measurement channels =====
+[03_no] 3
+[03_name] pH(HP8)
+[03_filter_id] 402
+[03_filter_type] pH
+[03_gain_1] 7
+[03_gain_2] 1
+[03_calibration] 2117121_comp
+===== measurement channels =====
+[04_no] 4
+[04_name] DO(PSt3)
+[04_filter_id] 403
+[04_filter_type] DO
+[04_gain_1] 7
+[04_gain_2] 1
+[04_calibration] 2117121_comp
+===== measurement channels =====
+[05_no] 5
+[05_name] Fluorescence5
+[05_filter_id] 427
+[05_filter_type] Intensity
+[05_gain_1] 5
+[05_gain_2] 1
+[05_calibration]
+===== measurement channels =====
+[06_no] 6
+[06_name] Fluorescence9
+[06_filter_id] 427
+[06_filter_type] Intensity
+[06_gain_1] 9
+[06_gain_2] 1
+[06_calibration]
+====== microfluidics settings ======
+[microfluidics] 1
+====== process ======
+[temperature] 30
+[humidity] 85
+[frequency] 1200
+[cycle-time] 510
+[exp-time] 0
+[temp-after-exp] 10
+[o2] -1
+[co2] -1
+[evacuation-time] -1
+=====temperature-profile=====
+[no_temperature_points] 0
+=====humidity-profile=====
+[no_humidity_points] 0
+=====shaker-profile=====
+[no_shaker_points] 0
+=====co2-profile=====
+[no_co2_points] 0
+=====o2-profile=====
+[no_o2_points] 0
+=====cover-profile=====
+[no_cover_points] 0
+=====pause-profile=====
+[no_pause_points] 0
+=====LAM=====
+[lam_mode] 0
+====== microfluidics settings ======
+[chip_type] 2R
+[max_well_volume] 1500
+[fill_profile_name] TIST-2840
+[ph_control_profile_name] TIST-5588
+[ph_control_profile_act_name]
+[1_feed_profile_name]
+[1_feed_profile_act_name]
+[2_feed_profile_name]
+[2_feed_profile_act_name]
+[ctrl_mode-dosing_r1] 2
+[ctrl_mode-dosing_r2] 2
+[ctrl_mode-dosing_r3] 1
+[ph_src_acid] B
+[ph_src_base] A
+[1_feed_src] N
+[2_feed_src] N
+[src_rows] A;B;
+===== microfluidics lot settings =====
+[lot_no]
+[v_prime1] 0
+[v_prime2] 0
+[v_prime3] 0
+[v_prime4] 0
+[v_prime5] 0
+[v_prime6] 0
+[v_prime7] 0
+[v_prime8] 0
+[v_prime9] 0
+[v_prime10] 0
+[v_prime11] 0
+[v_prime12] 0
+[k1] 1
+[k2] 1
+[k3] 1
+[k4] 1
+[k5] 1
+[k6] 1
+[k7] 1
+[k8] 1
+[k9] 1
+[k10] 1
+[k11] 1
+[k12] 1
+===== microfluidics pH control configuration =====
+[start_valve_open] 57.1428571428572
+[deadband_value] 0.05
+[pressure_drop_pa] 50000
+===== microfluidics source wells =====
+[no_src] 16
+[01_src_well] A01
+[01_src_med]
+[01_src_conc] 0.01
+[01_src_v_p] 0.3
+[01_src_vis] 1
+[01_src_temp] 20
+[01_src_vol] 1200
+[02_src_well] A02
+[02_src_med]
+[02_src_conc] 0.01
+[02_src_v_p] 0.3
+[02_src_vis] 1
+[02_src_temp] 20
+[02_src_vol] 1200
+[03_src_well] A03
+[03_src_med]
+[03_src_conc] 0.01
+[03_src_v_p] 0.3
+[03_src_vis] 1
+[03_src_temp] 20
+[03_src_vol] 1200
+[04_src_well] A04
+[04_src_med]
+[04_src_conc] 0.01
+[04_src_v_p] 0.3
+[04_src_vis] 1
+[04_src_temp] 20
+[04_src_vol] 1200
+[05_src_well] A05
+[05_src_med]
+[05_src_conc] 0.01
+[05_src_v_p] 0.3
+[05_src_vis] 1
+[05_src_temp] 20
+[05_src_vol] 1200
+[06_src_well] A06
+[06_src_med]
+[06_src_conc] 0.01
+[06_src_v_p] 0.3
+[06_src_vis] 1
+[06_src_temp] 20
+[06_src_vol] 1200
+[07_src_well] A07
+[07_src_med]
+[07_src_conc] 0.01
+[07_src_v_p] 0.3
+[07_src_vis] 1
+[07_src_temp] 20
+[07_src_vol] 1200
+[08_src_well] A08
+[08_src_med]
+[08_src_conc] 0.01
+[08_src_v_p] 0.3
+[08_src_vis] 1
+[08_src_temp] 20
+[08_src_vol] 1200
+[09_src_well] B01
+[09_src_med]
+[09_src_conc] 0.01
+[09_src_v_p] 0.3
+[09_src_vis] 1
+[09_src_temp] 20
+[09_src_vol] 1200
+[10_src_well] B02
+[10_src_med]
+[10_src_conc] 0.01
+[10_src_v_p] 0.3
+[10_src_vis] 1
+[10_src_temp] 20
+[10_src_vol] 1200
+[11_src_well] B03
+[11_src_med]
+[11_src_conc] 0.01
+[11_src_v_p] 0.3
+[11_src_vis] 1
+[11_src_temp] 20
+[11_src_vol] 1200
+[12_src_well] B04
+[12_src_med]
+[12_src_conc] 0.01
+[12_src_v_p] 0.3
+[12_src_vis] 1
+[12_src_temp] 20
+[12_src_vol] 1200
+[13_src_well] B05
+[13_src_med]
+[13_src_conc] 0.01
+[13_src_v_p] 0.3
+[13_src_vis] 1
+[13_src_temp] 20
+[13_src_vol] 1200
+[14_src_well] B06
+[14_src_med]
+[14_src_conc] 0.01
+[14_src_v_p] 0.3
+[14_src_vis] 1
+[14_src_temp] 20
+[14_src_vol] 1200
+[15_src_well] B07
+[15_src_med]
+[15_src_conc] 0.01
+[15_src_v_p] 0.3
+[15_src_vis] 1
+[15_src_temp] 20
+[15_src_vol] 1200
+[16_src_well] B08
+[16_src_med]
+[16_src_conc] 0.01
+[16_src_v_p] 0.3
+[16_src_vis] 1
+[16_src_temp] 20
+[16_src_vol] 1200
+====== fermentations ======
+[no_fermentation] 32
+===== fermentation =====
+[001_well] C01
+[001_content] X1
+[001_description]
+[001_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[001_01_measure] 1
+[001_01_x] 15.5
+[001_01_y] 36.5
+== calibration ==
+[001_01_cal-mode] NONE
+=== measurement ===
+[001_02_measure] 1
+[001_02_x] 15.5
+[001_02_y] 36.5
+== calibration ==
+[001_02_cal-mode] NONE
+=== measurement ===
+[001_03_measure] 1
+[001_03_x] 19.5
+[001_03_y] 33.5
+== calibration ==
+[001_03_cal-mode] PH
+[001_03_temp-comp] 1
+[001_03_temp_min] 20
+[001_03_temp_max] 40
+[001_03_fmin_a] 66.90742
+[001_03_fmin_m] -0.08812
+[001_03_fmax_a] 14.60001
+[001_03_fmax_m] -4E-05
+[001_03_ph0_a] 6.51001
+[001_03_ph0_m] -0.01053
+[001_03_dph_a] 0.59142
+[001_03_dph_m] -0.00083
+=== measurement ===
+[001_04_measure] 1
+[001_04_x] 18.5
+[001_04_y] 38
+== calibration ==
+[001_04_cal-mode] DO
+[001_04_temp-comp] 1
+[001_04_temp_min] 20
+[001_04_temp_max] 40
+[001_04_k0_m] -0.05315
+[001_04_k0_a] 74.85616667
+[001_04_k100_m] -0.235033333
+[001_04_k100_a] 48.59816667
+=== measurement ===
+[001_05_measure] 1
+[001_05_x] 15.5
+[001_05_y] 36.5
+== calibration ==
+[001_05_cal-mode] NONE
+=== measurement ===
+[001_06_measure] 1
+[001_06_x] 15.5
+[001_06_y] 36.5
+== calibration ==
+[001_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[001_ph] 1
+[001_ph_max_valve_open] 3428.57142857143
+[001_ph_min_valve_open] 28.5714285714286
+[001_ph_p_band_value] 1
+[001_ph_integrator] 1
+[001_ph_buffering_capacity] MEDIUM
+[001_no_ph_sp] 1
+[001_01_ph_tim] 0
+[001_01_ph_val] 6.6
+[001_ph_sgnl] 3
+[001_ph_sgnl_cal] 1
+[001_ph_src_acid] B01
+[001_ph_src_base] A01
+[001_ph_act] 0
+= 1.feed control =
+[001_1_feed] 0
+= 2.feed control =
+[001_2_feed] 0
+===== fermentation =====
+[002_well] C02
+[002_content] X2
+[002_description]
+[002_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[002_01_measure] 1
+[002_01_x] 28.5
+[002_01_y] 36.5
+== calibration ==
+[002_01_cal-mode] NONE
+=== measurement ===
+[002_02_measure] 1
+[002_02_x] 28.5
+[002_02_y] 36.5
+== calibration ==
+[002_02_cal-mode] NONE
+=== measurement ===
+[002_03_measure] 1
+[002_03_x] 32.5
+[002_03_y] 33.5
+== calibration ==
+[002_03_cal-mode] PH
+[002_03_temp-comp] 1
+[002_03_temp_min] 20
+[002_03_temp_max] 40
+[002_03_fmin_a] 66.90742
+[002_03_fmin_m] -0.08812
+[002_03_fmax_a] 14.60001
+[002_03_fmax_m] -4E-05
+[002_03_ph0_a] 6.51001
+[002_03_ph0_m] -0.01053
+[002_03_dph_a] 0.59142
+[002_03_dph_m] -0.00083
+=== measurement ===
+[002_04_measure] 1
+[002_04_x] 31.5
+[002_04_y] 38
+== calibration ==
+[002_04_cal-mode] DO
+[002_04_temp-comp] 1
+[002_04_temp_min] 20
+[002_04_temp_max] 40
+[002_04_k0_m] -0.05315
+[002_04_k0_a] 74.85616667
+[002_04_k100_m] -0.235033333
+[002_04_k100_a] 48.59816667
+=== measurement ===
+[002_05_measure] 1
+[002_05_x] 28.5
+[002_05_y] 36.5
+== calibration ==
+[002_05_cal-mode] NONE
+=== measurement ===
+[002_06_measure] 1
+[002_06_x] 28.5
+[002_06_y] 36.5
+== calibration ==
+[002_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[002_ph] 1
+[002_ph_max_valve_open] 3428.57142857143
+[002_ph_min_valve_open] 28.5714285714286
+[002_ph_p_band_value] 1
+[002_ph_integrator] 1
+[002_ph_buffering_capacity] MEDIUM
+[002_no_ph_sp] 1
+[002_01_ph_tim] 0
+[002_01_ph_val] 6.6
+[002_ph_sgnl] 3
+[002_ph_sgnl_cal] 1
+[002_ph_src_acid] B02
+[002_ph_src_base] A02
+[002_ph_act] 0
+= 1.feed control =
+[002_1_feed] 0
+= 2.feed control =
+[002_2_feed] 0
+===== fermentation =====
+[003_well] C03
+[003_content] X3
+[003_description]
+[003_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[003_01_measure] 1
+[003_01_x] 41.5
+[003_01_y] 36.5
+== calibration ==
+[003_01_cal-mode] NONE
+=== measurement ===
+[003_02_measure] 1
+[003_02_x] 41.5
+[003_02_y] 36.5
+== calibration ==
+[003_02_cal-mode] NONE
+=== measurement ===
+[003_03_measure] 1
+[003_03_x] 45.5
+[003_03_y] 33.5
+== calibration ==
+[003_03_cal-mode] PH
+[003_03_temp-comp] 1
+[003_03_temp_min] 20
+[003_03_temp_max] 40
+[003_03_fmin_a] 66.90742
+[003_03_fmin_m] -0.08812
+[003_03_fmax_a] 14.60001
+[003_03_fmax_m] -4E-05
+[003_03_ph0_a] 6.51001
+[003_03_ph0_m] -0.01053
+[003_03_dph_a] 0.59142
+[003_03_dph_m] -0.00083
+=== measurement ===
+[003_04_measure] 1
+[003_04_x] 44.5
+[003_04_y] 38
+== calibration ==
+[003_04_cal-mode] DO
+[003_04_temp-comp] 1
+[003_04_temp_min] 20
+[003_04_temp_max] 40
+[003_04_k0_m] -0.05315
+[003_04_k0_a] 74.85616667
+[003_04_k100_m] -0.235033333
+[003_04_k100_a] 48.59816667
+=== measurement ===
+[003_05_measure] 1
+[003_05_x] 41.5
+[003_05_y] 36.5
+== calibration ==
+[003_05_cal-mode] NONE
+=== measurement ===
+[003_06_measure] 1
+[003_06_x] 41.5
+[003_06_y] 36.5
+== calibration ==
+[003_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[003_ph] 1
+[003_ph_max_valve_open] 3428.57142857143
+[003_ph_min_valve_open] 28.5714285714286
+[003_ph_p_band_value] 1
+[003_ph_integrator] 1
+[003_ph_buffering_capacity] MEDIUM
+[003_no_ph_sp] 1
+[003_01_ph_tim] 0
+[003_01_ph_val] 6.6
+[003_ph_sgnl] 3
+[003_ph_sgnl_cal] 1
+[003_ph_src_acid] B03
+[003_ph_src_base] A03
+[003_ph_act] 0
+= 1.feed control =
+[003_1_feed] 0
+= 2.feed control =
+[003_2_feed] 0
+===== fermentation =====
+[004_well] C04
+[004_content] X4
+[004_description]
+[004_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[004_01_measure] 1
+[004_01_x] 54.5
+[004_01_y] 36.5
+== calibration ==
+[004_01_cal-mode] NONE
+=== measurement ===
+[004_02_measure] 1
+[004_02_x] 54.5
+[004_02_y] 36.5
+== calibration ==
+[004_02_cal-mode] NONE
+=== measurement ===
+[004_03_measure] 1
+[004_03_x] 58.5
+[004_03_y] 33.5
+== calibration ==
+[004_03_cal-mode] PH
+[004_03_temp-comp] 1
+[004_03_temp_min] 20
+[004_03_temp_max] 40
+[004_03_fmin_a] 66.90742
+[004_03_fmin_m] -0.08812
+[004_03_fmax_a] 14.60001
+[004_03_fmax_m] -4E-05
+[004_03_ph0_a] 6.51001
+[004_03_ph0_m] -0.01053
+[004_03_dph_a] 0.59142
+[004_03_dph_m] -0.00083
+=== measurement ===
+[004_04_measure] 1
+[004_04_x] 57.5
+[004_04_y] 38
+== calibration ==
+[004_04_cal-mode] DO
+[004_04_temp-comp] 1
+[004_04_temp_min] 20
+[004_04_temp_max] 40
+[004_04_k0_m] -0.05315
+[004_04_k0_a] 74.85616667
+[004_04_k100_m] -0.235033333
+[004_04_k100_a] 48.59816667
+=== measurement ===
+[004_05_measure] 1
+[004_05_x] 54.5
+[004_05_y] 36.5
+== calibration ==
+[004_05_cal-mode] NONE
+=== measurement ===
+[004_06_measure] 1
+[004_06_x] 54.5
+[004_06_y] 36.5
+== calibration ==
+[004_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[004_ph] 1
+[004_ph_max_valve_open] 3428.57142857143
+[004_ph_min_valve_open] 28.5714285714286
+[004_ph_p_band_value] 1
+[004_ph_integrator] 1
+[004_ph_buffering_capacity] MEDIUM
+[004_no_ph_sp] 1
+[004_01_ph_tim] 0
+[004_01_ph_val] 6.6
+[004_ph_sgnl] 3
+[004_ph_sgnl_cal] 1
+[004_ph_src_acid] B04
+[004_ph_src_base] A04
+[004_ph_act] 0
+= 1.feed control =
+[004_1_feed] 0
+= 2.feed control =
+[004_2_feed] 0
+===== fermentation =====
+[005_well] C05
+[005_content] X5
+[005_description]
+[005_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[005_01_measure] 1
+[005_01_x] 67.5
+[005_01_y] 36.5
+== calibration ==
+[005_01_cal-mode] NONE
+=== measurement ===
+[005_02_measure] 1
+[005_02_x] 67.5
+[005_02_y] 36.5
+== calibration ==
+[005_02_cal-mode] NONE
+=== measurement ===
+[005_03_measure] 1
+[005_03_x] 71.5
+[005_03_y] 33.5
+== calibration ==
+[005_03_cal-mode] PH
+[005_03_temp-comp] 1
+[005_03_temp_min] 20
+[005_03_temp_max] 40
+[005_03_fmin_a] 66.90742
+[005_03_fmin_m] -0.08812
+[005_03_fmax_a] 14.60001
+[005_03_fmax_m] -4E-05
+[005_03_ph0_a] 6.51001
+[005_03_ph0_m] -0.01053
+[005_03_dph_a] 0.59142
+[005_03_dph_m] -0.00083
+=== measurement ===
+[005_04_measure] 1
+[005_04_x] 70.5
+[005_04_y] 38
+== calibration ==
+[005_04_cal-mode] DO
+[005_04_temp-comp] 1
+[005_04_temp_min] 20
+[005_04_temp_max] 40
+[005_04_k0_m] -0.05315
+[005_04_k0_a] 74.85616667
+[005_04_k100_m] -0.235033333
+[005_04_k100_a] 48.59816667
+=== measurement ===
+[005_05_measure] 1
+[005_05_x] 67.5
+[005_05_y] 36.5
+== calibration ==
+[005_05_cal-mode] NONE
+=== measurement ===
+[005_06_measure] 1
+[005_06_x] 67.5
+[005_06_y] 36.5
+== calibration ==
+[005_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[005_ph] 1
+[005_ph_max_valve_open] 3428.57142857143
+[005_ph_min_valve_open] 28.5714285714286
+[005_ph_p_band_value] 1
+[005_ph_integrator] 1
+[005_ph_buffering_capacity] MEDIUM
+[005_no_ph_sp] 1
+[005_01_ph_tim] 0
+[005_01_ph_val] 6.6
+[005_ph_sgnl] 3
+[005_ph_sgnl_cal] 1
+[005_ph_src_acid] B05
+[005_ph_src_base] A05
+[005_ph_act] 0
+= 1.feed control =
+[005_1_feed] 0
+= 2.feed control =
+[005_2_feed] 0
+===== fermentation =====
+[006_well] C06
+[006_content] X6
+[006_description]
+[006_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[006_01_measure] 1
+[006_01_x] 80.5
+[006_01_y] 36.5
+== calibration ==
+[006_01_cal-mode] NONE
+=== measurement ===
+[006_02_measure] 1
+[006_02_x] 80.5
+[006_02_y] 36.5
+== calibration ==
+[006_02_cal-mode] NONE
+=== measurement ===
+[006_03_measure] 1
+[006_03_x] 84.5
+[006_03_y] 33.5
+== calibration ==
+[006_03_cal-mode] PH
+[006_03_temp-comp] 1
+[006_03_temp_min] 20
+[006_03_temp_max] 40
+[006_03_fmin_a] 66.90742
+[006_03_fmin_m] -0.08812
+[006_03_fmax_a] 14.60001
+[006_03_fmax_m] -4E-05
+[006_03_ph0_a] 6.51001
+[006_03_ph0_m] -0.01053
+[006_03_dph_a] 0.59142
+[006_03_dph_m] -0.00083
+=== measurement ===
+[006_04_measure] 1
+[006_04_x] 83.5
+[006_04_y] 38
+== calibration ==
+[006_04_cal-mode] DO
+[006_04_temp-comp] 1
+[006_04_temp_min] 20
+[006_04_temp_max] 40
+[006_04_k0_m] -0.05315
+[006_04_k0_a] 74.85616667
+[006_04_k100_m] -0.235033333
+[006_04_k100_a] 48.59816667
+=== measurement ===
+[006_05_measure] 1
+[006_05_x] 80.5
+[006_05_y] 36.5
+== calibration ==
+[006_05_cal-mode] NONE
+=== measurement ===
+[006_06_measure] 1
+[006_06_x] 80.5
+[006_06_y] 36.5
+== calibration ==
+[006_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[006_ph] 1
+[006_ph_max_valve_open] 3428.57142857143
+[006_ph_min_valve_open] 28.5714285714286
+[006_ph_p_band_value] 1
+[006_ph_integrator] 1
+[006_ph_buffering_capacity] MEDIUM
+[006_no_ph_sp] 1
+[006_01_ph_tim] 0
+[006_01_ph_val] 6.6
+[006_ph_sgnl] 3
+[006_ph_sgnl_cal] 1
+[006_ph_src_acid] B06
+[006_ph_src_base] A06
+[006_ph_act] 0
+= 1.feed control =
+[006_1_feed] 0
+= 2.feed control =
+[006_2_feed] 0
+===== fermentation =====
+[007_well] C07
+[007_content] X7
+[007_description]
+[007_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[007_01_measure] 1
+[007_01_x] 93.5
+[007_01_y] 36.5
+== calibration ==
+[007_01_cal-mode] NONE
+=== measurement ===
+[007_02_measure] 1
+[007_02_x] 93.5
+[007_02_y] 36.5
+== calibration ==
+[007_02_cal-mode] NONE
+=== measurement ===
+[007_03_measure] 1
+[007_03_x] 97.5
+[007_03_y] 33.5
+== calibration ==
+[007_03_cal-mode] PH
+[007_03_temp-comp] 1
+[007_03_temp_min] 20
+[007_03_temp_max] 40
+[007_03_fmin_a] 66.90742
+[007_03_fmin_m] -0.08812
+[007_03_fmax_a] 14.60001
+[007_03_fmax_m] -4E-05
+[007_03_ph0_a] 6.51001
+[007_03_ph0_m] -0.01053
+[007_03_dph_a] 0.59142
+[007_03_dph_m] -0.00083
+=== measurement ===
+[007_04_measure] 1
+[007_04_x] 96.5
+[007_04_y] 38
+== calibration ==
+[007_04_cal-mode] DO
+[007_04_temp-comp] 1
+[007_04_temp_min] 20
+[007_04_temp_max] 40
+[007_04_k0_m] -0.05315
+[007_04_k0_a] 74.85616667
+[007_04_k100_m] -0.235033333
+[007_04_k100_a] 48.59816667
+=== measurement ===
+[007_05_measure] 1
+[007_05_x] 93.5
+[007_05_y] 36.5
+== calibration ==
+[007_05_cal-mode] NONE
+=== measurement ===
+[007_06_measure] 1
+[007_06_x] 93.5
+[007_06_y] 36.5
+== calibration ==
+[007_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[007_ph] 1
+[007_ph_max_valve_open] 3428.57142857143
+[007_ph_min_valve_open] 28.5714285714286
+[007_ph_p_band_value] 1
+[007_ph_integrator] 1
+[007_ph_buffering_capacity] MEDIUM
+[007_no_ph_sp] 1
+[007_01_ph_tim] 0
+[007_01_ph_val] 6.6
+[007_ph_sgnl] 3
+[007_ph_sgnl_cal] 1
+[007_ph_src_acid] B07
+[007_ph_src_base] A07
+[007_ph_act] 0
+= 1.feed control =
+[007_1_feed] 0
+= 2.feed control =
+[007_2_feed] 0
+===== fermentation =====
+[008_well] C08
+[008_content] X8
+[008_description]
+[008_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[008_01_measure] 1
+[008_01_x] 106.5
+[008_01_y] 36.5
+== calibration ==
+[008_01_cal-mode] NONE
+=== measurement ===
+[008_02_measure] 1
+[008_02_x] 106.5
+[008_02_y] 36.5
+== calibration ==
+[008_02_cal-mode] NONE
+=== measurement ===
+[008_03_measure] 1
+[008_03_x] 110.5
+[008_03_y] 33.5
+== calibration ==
+[008_03_cal-mode] PH
+[008_03_temp-comp] 1
+[008_03_temp_min] 20
+[008_03_temp_max] 40
+[008_03_fmin_a] 66.90742
+[008_03_fmin_m] -0.08812
+[008_03_fmax_a] 14.60001
+[008_03_fmax_m] -4E-05
+[008_03_ph0_a] 6.51001
+[008_03_ph0_m] -0.01053
+[008_03_dph_a] 0.59142
+[008_03_dph_m] -0.00083
+=== measurement ===
+[008_04_measure] 1
+[008_04_x] 109.5
+[008_04_y] 38
+== calibration ==
+[008_04_cal-mode] DO
+[008_04_temp-comp] 1
+[008_04_temp_min] 20
+[008_04_temp_max] 40
+[008_04_k0_m] -0.05315
+[008_04_k0_a] 74.85616667
+[008_04_k100_m] -0.235033333
+[008_04_k100_a] 48.59816667
+=== measurement ===
+[008_05_measure] 1
+[008_05_x] 106.5
+[008_05_y] 36.5
+== calibration ==
+[008_05_cal-mode] NONE
+=== measurement ===
+[008_06_measure] 1
+[008_06_x] 106.5
+[008_06_y] 36.5
+== calibration ==
+[008_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[008_ph] 1
+[008_ph_max_valve_open] 3428.57142857143
+[008_ph_min_valve_open] 28.5714285714286
+[008_ph_p_band_value] 1
+[008_ph_integrator] 1
+[008_ph_buffering_capacity] MEDIUM
+[008_no_ph_sp] 1
+[008_01_ph_tim] 0
+[008_01_ph_val] 6.6
+[008_ph_sgnl] 3
+[008_ph_sgnl_cal] 1
+[008_ph_src_acid] B08
+[008_ph_src_base] A08
+[008_ph_act] 0
+= 1.feed control =
+[008_1_feed] 0
+= 2.feed control =
+[008_2_feed] 0
+===== fermentation =====
+[009_well] D08
+[009_content] X16
+[009_description]
+[009_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[009_01_measure] 1
+[009_01_x] 106.5
+[009_01_y] 49.5
+== calibration ==
+[009_01_cal-mode] NONE
+=== measurement ===
+[009_02_measure] 1
+[009_02_x] 106.5
+[009_02_y] 49.5
+== calibration ==
+[009_02_cal-mode] NONE
+=== measurement ===
+[009_03_measure] 1
+[009_03_x] 110.5
+[009_03_y] 46.5
+== calibration ==
+[009_03_cal-mode] PH
+[009_03_temp-comp] 1
+[009_03_temp_min] 20
+[009_03_temp_max] 40
+[009_03_fmin_a] 66.90742
+[009_03_fmin_m] -0.08812
+[009_03_fmax_a] 14.60001
+[009_03_fmax_m] -4E-05
+[009_03_ph0_a] 6.51001
+[009_03_ph0_m] -0.01053
+[009_03_dph_a] 0.59142
+[009_03_dph_m] -0.00083
+=== measurement ===
+[009_04_measure] 1
+[009_04_x] 109.5
+[009_04_y] 51
+== calibration ==
+[009_04_cal-mode] DO
+[009_04_temp-comp] 1
+[009_04_temp_min] 20
+[009_04_temp_max] 40
+[009_04_k0_m] -0.05315
+[009_04_k0_a] 74.85616667
+[009_04_k100_m] -0.235033333
+[009_04_k100_a] 48.59816667
+=== measurement ===
+[009_05_measure] 1
+[009_05_x] 106.5
+[009_05_y] 49.5
+== calibration ==
+[009_05_cal-mode] NONE
+=== measurement ===
+[009_06_measure] 1
+[009_06_x] 106.5
+[009_06_y] 49.5
+== calibration ==
+[009_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[009_ph] 1
+[009_ph_max_valve_open] 3428.57142857143
+[009_ph_min_valve_open] 28.5714285714286
+[009_ph_p_band_value] 1
+[009_ph_integrator] 1
+[009_ph_buffering_capacity] MEDIUM
+[009_no_ph_sp] 1
+[009_01_ph_tim] 0
+[009_01_ph_val] 6.6
+[009_ph_sgnl] 3
+[009_ph_sgnl_cal] 1
+[009_ph_src_acid] B08
+[009_ph_src_base] A08
+[009_ph_act] 0
+= 1.feed control =
+[009_1_feed] 0
+= 2.feed control =
+[009_2_feed] 0
+===== fermentation =====
+[010_well] D07
+[010_content] X15
+[010_description]
+[010_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[010_01_measure] 1
+[010_01_x] 93.5
+[010_01_y] 49.5
+== calibration ==
+[010_01_cal-mode] NONE
+=== measurement ===
+[010_02_measure] 1
+[010_02_x] 93.5
+[010_02_y] 49.5
+== calibration ==
+[010_02_cal-mode] NONE
+=== measurement ===
+[010_03_measure] 1
+[010_03_x] 97.5
+[010_03_y] 46.5
+== calibration ==
+[010_03_cal-mode] PH
+[010_03_temp-comp] 1
+[010_03_temp_min] 20
+[010_03_temp_max] 40
+[010_03_fmin_a] 66.90742
+[010_03_fmin_m] -0.08812
+[010_03_fmax_a] 14.60001
+[010_03_fmax_m] -4E-05
+[010_03_ph0_a] 6.51001
+[010_03_ph0_m] -0.01053
+[010_03_dph_a] 0.59142
+[010_03_dph_m] -0.00083
+=== measurement ===
+[010_04_measure] 1
+[010_04_x] 96.5
+[010_04_y] 51
+== calibration ==
+[010_04_cal-mode] DO
+[010_04_temp-comp] 1
+[010_04_temp_min] 20
+[010_04_temp_max] 40
+[010_04_k0_m] -0.05315
+[010_04_k0_a] 74.85616667
+[010_04_k100_m] -0.235033333
+[010_04_k100_a] 48.59816667
+=== measurement ===
+[010_05_measure] 1
+[010_05_x] 93.5
+[010_05_y] 49.5
+== calibration ==
+[010_05_cal-mode] NONE
+=== measurement ===
+[010_06_measure] 1
+[010_06_x] 93.5
+[010_06_y] 49.5
+== calibration ==
+[010_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[010_ph] 1
+[010_ph_max_valve_open] 3428.57142857143
+[010_ph_min_valve_open] 28.5714285714286
+[010_ph_p_band_value] 1
+[010_ph_integrator] 1
+[010_ph_buffering_capacity] MEDIUM
+[010_no_ph_sp] 1
+[010_01_ph_tim] 0
+[010_01_ph_val] 6.6
+[010_ph_sgnl] 3
+[010_ph_sgnl_cal] 1
+[010_ph_src_acid] B07
+[010_ph_src_base] A07
+[010_ph_act] 0
+= 1.feed control =
+[010_1_feed] 0
+= 2.feed control =
+[010_2_feed] 0
+===== fermentation =====
+[011_well] D06
+[011_content] X14
+[011_description]
+[011_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[011_01_measure] 1
+[011_01_x] 80.5
+[011_01_y] 49.5
+== calibration ==
+[011_01_cal-mode] NONE
+=== measurement ===
+[011_02_measure] 1
+[011_02_x] 80.5
+[011_02_y] 49.5
+== calibration ==
+[011_02_cal-mode] NONE
+=== measurement ===
+[011_03_measure] 1
+[011_03_x] 84.5
+[011_03_y] 46.5
+== calibration ==
+[011_03_cal-mode] PH
+[011_03_temp-comp] 1
+[011_03_temp_min] 20
+[011_03_temp_max] 40
+[011_03_fmin_a] 66.90742
+[011_03_fmin_m] -0.08812
+[011_03_fmax_a] 14.60001
+[011_03_fmax_m] -4E-05
+[011_03_ph0_a] 6.51001
+[011_03_ph0_m] -0.01053
+[011_03_dph_a] 0.59142
+[011_03_dph_m] -0.00083
+=== measurement ===
+[011_04_measure] 1
+[011_04_x] 83.5
+[011_04_y] 51
+== calibration ==
+[011_04_cal-mode] DO
+[011_04_temp-comp] 1
+[011_04_temp_min] 20
+[011_04_temp_max] 40
+[011_04_k0_m] -0.05315
+[011_04_k0_a] 74.85616667
+[011_04_k100_m] -0.235033333
+[011_04_k100_a] 48.59816667
+=== measurement ===
+[011_05_measure] 1
+[011_05_x] 80.5
+[011_05_y] 49.5
+== calibration ==
+[011_05_cal-mode] NONE
+=== measurement ===
+[011_06_measure] 1
+[011_06_x] 80.5
+[011_06_y] 49.5
+== calibration ==
+[011_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[011_ph] 1
+[011_ph_max_valve_open] 3428.57142857143
+[011_ph_min_valve_open] 28.5714285714286
+[011_ph_p_band_value] 1
+[011_ph_integrator] 1
+[011_ph_buffering_capacity] MEDIUM
+[011_no_ph_sp] 1
+[011_01_ph_tim] 0
+[011_01_ph_val] 6.6
+[011_ph_sgnl] 3
+[011_ph_sgnl_cal] 1
+[011_ph_src_acid] B06
+[011_ph_src_base] A06
+[011_ph_act] 0
+= 1.feed control =
+[011_1_feed] 0
+= 2.feed control =
+[011_2_feed] 0
+===== fermentation =====
+[012_well] D05
+[012_content] X13
+[012_description]
+[012_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[012_01_measure] 1
+[012_01_x] 67.5
+[012_01_y] 49.5
+== calibration ==
+[012_01_cal-mode] NONE
+=== measurement ===
+[012_02_measure] 1
+[012_02_x] 67.5
+[012_02_y] 49.5
+== calibration ==
+[012_02_cal-mode] NONE
+=== measurement ===
+[012_03_measure] 1
+[012_03_x] 71.5
+[012_03_y] 46.5
+== calibration ==
+[012_03_cal-mode] PH
+[012_03_temp-comp] 1
+[012_03_temp_min] 20
+[012_03_temp_max] 40
+[012_03_fmin_a] 66.90742
+[012_03_fmin_m] -0.08812
+[012_03_fmax_a] 14.60001
+[012_03_fmax_m] -4E-05
+[012_03_ph0_a] 6.51001
+[012_03_ph0_m] -0.01053
+[012_03_dph_a] 0.59142
+[012_03_dph_m] -0.00083
+=== measurement ===
+[012_04_measure] 1
+[012_04_x] 70.5
+[012_04_y] 51
+== calibration ==
+[012_04_cal-mode] DO
+[012_04_temp-comp] 1
+[012_04_temp_min] 20
+[012_04_temp_max] 40
+[012_04_k0_m] -0.05315
+[012_04_k0_a] 74.85616667
+[012_04_k100_m] -0.235033333
+[012_04_k100_a] 48.59816667
+=== measurement ===
+[012_05_measure] 1
+[012_05_x] 67.5
+[012_05_y] 49.5
+== calibration ==
+[012_05_cal-mode] NONE
+=== measurement ===
+[012_06_measure] 1
+[012_06_x] 67.5
+[012_06_y] 49.5
+== calibration ==
+[012_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[012_ph] 1
+[012_ph_max_valve_open] 3428.57142857143
+[012_ph_min_valve_open] 28.5714285714286
+[012_ph_p_band_value] 1
+[012_ph_integrator] 1
+[012_ph_buffering_capacity] MEDIUM
+[012_no_ph_sp] 1
+[012_01_ph_tim] 0
+[012_01_ph_val] 6.6
+[012_ph_sgnl] 3
+[012_ph_sgnl_cal] 1
+[012_ph_src_acid] B05
+[012_ph_src_base] A05
+[012_ph_act] 0
+= 1.feed control =
+[012_1_feed] 0
+= 2.feed control =
+[012_2_feed] 0
+===== fermentation =====
+[013_well] D04
+[013_content] X12
+[013_description]
+[013_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[013_01_measure] 1
+[013_01_x] 54.5
+[013_01_y] 49.5
+== calibration ==
+[013_01_cal-mode] NONE
+=== measurement ===
+[013_02_measure] 1
+[013_02_x] 54.5
+[013_02_y] 49.5
+== calibration ==
+[013_02_cal-mode] NONE
+=== measurement ===
+[013_03_measure] 1
+[013_03_x] 58.5
+[013_03_y] 46.5
+== calibration ==
+[013_03_cal-mode] PH
+[013_03_temp-comp] 1
+[013_03_temp_min] 20
+[013_03_temp_max] 40
+[013_03_fmin_a] 66.90742
+[013_03_fmin_m] -0.08812
+[013_03_fmax_a] 14.60001
+[013_03_fmax_m] -4E-05
+[013_03_ph0_a] 6.51001
+[013_03_ph0_m] -0.01053
+[013_03_dph_a] 0.59142
+[013_03_dph_m] -0.00083
+=== measurement ===
+[013_04_measure] 1
+[013_04_x] 57.5
+[013_04_y] 51
+== calibration ==
+[013_04_cal-mode] DO
+[013_04_temp-comp] 1
+[013_04_temp_min] 20
+[013_04_temp_max] 40
+[013_04_k0_m] -0.05315
+[013_04_k0_a] 74.85616667
+[013_04_k100_m] -0.235033333
+[013_04_k100_a] 48.59816667
+=== measurement ===
+[013_05_measure] 1
+[013_05_x] 54.5
+[013_05_y] 49.5
+== calibration ==
+[013_05_cal-mode] NONE
+=== measurement ===
+[013_06_measure] 1
+[013_06_x] 54.5
+[013_06_y] 49.5
+== calibration ==
+[013_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[013_ph] 1
+[013_ph_max_valve_open] 3428.57142857143
+[013_ph_min_valve_open] 28.5714285714286
+[013_ph_p_band_value] 1
+[013_ph_integrator] 1
+[013_ph_buffering_capacity] MEDIUM
+[013_no_ph_sp] 1
+[013_01_ph_tim] 0
+[013_01_ph_val] 6.6
+[013_ph_sgnl] 3
+[013_ph_sgnl_cal] 1
+[013_ph_src_acid] B04
+[013_ph_src_base] A04
+[013_ph_act] 0
+= 1.feed control =
+[013_1_feed] 0
+= 2.feed control =
+[013_2_feed] 0
+===== fermentation =====
+[014_well] D03
+[014_content] X11
+[014_description]
+[014_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[014_01_measure] 1
+[014_01_x] 41.5
+[014_01_y] 49.5
+== calibration ==
+[014_01_cal-mode] NONE
+=== measurement ===
+[014_02_measure] 1
+[014_02_x] 41.5
+[014_02_y] 49.5
+== calibration ==
+[014_02_cal-mode] NONE
+=== measurement ===
+[014_03_measure] 1
+[014_03_x] 45.5
+[014_03_y] 46.5
+== calibration ==
+[014_03_cal-mode] PH
+[014_03_temp-comp] 1
+[014_03_temp_min] 20
+[014_03_temp_max] 40
+[014_03_fmin_a] 66.90742
+[014_03_fmin_m] -0.08812
+[014_03_fmax_a] 14.60001
+[014_03_fmax_m] -4E-05
+[014_03_ph0_a] 6.51001
+[014_03_ph0_m] -0.01053
+[014_03_dph_a] 0.59142
+[014_03_dph_m] -0.00083
+=== measurement ===
+[014_04_measure] 1
+[014_04_x] 44.5
+[014_04_y] 51
+== calibration ==
+[014_04_cal-mode] DO
+[014_04_temp-comp] 1
+[014_04_temp_min] 20
+[014_04_temp_max] 40
+[014_04_k0_m] -0.05315
+[014_04_k0_a] 74.85616667
+[014_04_k100_m] -0.235033333
+[014_04_k100_a] 48.59816667
+=== measurement ===
+[014_05_measure] 1
+[014_05_x] 41.5
+[014_05_y] 49.5
+== calibration ==
+[014_05_cal-mode] NONE
+=== measurement ===
+[014_06_measure] 1
+[014_06_x] 41.5
+[014_06_y] 49.5
+== calibration ==
+[014_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[014_ph] 1
+[014_ph_max_valve_open] 3428.57142857143
+[014_ph_min_valve_open] 28.5714285714286
+[014_ph_p_band_value] 1
+[014_ph_integrator] 1
+[014_ph_buffering_capacity] MEDIUM
+[014_no_ph_sp] 1
+[014_01_ph_tim] 0
+[014_01_ph_val] 6.6
+[014_ph_sgnl] 3
+[014_ph_sgnl_cal] 1
+[014_ph_src_acid] B03
+[014_ph_src_base] A03
+[014_ph_act] 0
+= 1.feed control =
+[014_1_feed] 0
+= 2.feed control =
+[014_2_feed] 0
+===== fermentation =====
+[015_well] D02
+[015_content] X10
+[015_description]
+[015_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[015_01_measure] 1
+[015_01_x] 28.5
+[015_01_y] 49.5
+== calibration ==
+[015_01_cal-mode] NONE
+=== measurement ===
+[015_02_measure] 1
+[015_02_x] 28.5
+[015_02_y] 49.5
+== calibration ==
+[015_02_cal-mode] NONE
+=== measurement ===
+[015_03_measure] 1
+[015_03_x] 32.5
+[015_03_y] 46.5
+== calibration ==
+[015_03_cal-mode] PH
+[015_03_temp-comp] 1
+[015_03_temp_min] 20
+[015_03_temp_max] 40
+[015_03_fmin_a] 66.90742
+[015_03_fmin_m] -0.08812
+[015_03_fmax_a] 14.60001
+[015_03_fmax_m] -4E-05
+[015_03_ph0_a] 6.51001
+[015_03_ph0_m] -0.01053
+[015_03_dph_a] 0.59142
+[015_03_dph_m] -0.00083
+=== measurement ===
+[015_04_measure] 1
+[015_04_x] 31.5
+[015_04_y] 51
+== calibration ==
+[015_04_cal-mode] DO
+[015_04_temp-comp] 1
+[015_04_temp_min] 20
+[015_04_temp_max] 40
+[015_04_k0_m] -0.05315
+[015_04_k0_a] 74.85616667
+[015_04_k100_m] -0.235033333
+[015_04_k100_a] 48.59816667
+=== measurement ===
+[015_05_measure] 1
+[015_05_x] 28.5
+[015_05_y] 49.5
+== calibration ==
+[015_05_cal-mode] NONE
+=== measurement ===
+[015_06_measure] 1
+[015_06_x] 28.5
+[015_06_y] 49.5
+== calibration ==
+[015_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[015_ph] 1
+[015_ph_max_valve_open] 3428.57142857143
+[015_ph_min_valve_open] 28.5714285714286
+[015_ph_p_band_value] 1
+[015_ph_integrator] 1
+[015_ph_buffering_capacity] MEDIUM
+[015_no_ph_sp] 1
+[015_01_ph_tim] 0
+[015_01_ph_val] 6.6
+[015_ph_sgnl] 3
+[015_ph_sgnl_cal] 1
+[015_ph_src_acid] B02
+[015_ph_src_base] A02
+[015_ph_act] 0
+= 1.feed control =
+[015_1_feed] 0
+= 2.feed control =
+[015_2_feed] 0
+===== fermentation =====
+[016_well] D01
+[016_content] X9
+[016_description]
+[016_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[016_01_measure] 1
+[016_01_x] 15.5
+[016_01_y] 49.5
+== calibration ==
+[016_01_cal-mode] NONE
+=== measurement ===
+[016_02_measure] 1
+[016_02_x] 15.5
+[016_02_y] 49.5
+== calibration ==
+[016_02_cal-mode] NONE
+=== measurement ===
+[016_03_measure] 1
+[016_03_x] 19.5
+[016_03_y] 46.5
+== calibration ==
+[016_03_cal-mode] PH
+[016_03_temp-comp] 1
+[016_03_temp_min] 20
+[016_03_temp_max] 40
+[016_03_fmin_a] 66.90742
+[016_03_fmin_m] -0.08812
+[016_03_fmax_a] 14.60001
+[016_03_fmax_m] -4E-05
+[016_03_ph0_a] 6.51001
+[016_03_ph0_m] -0.01053
+[016_03_dph_a] 0.59142
+[016_03_dph_m] -0.00083
+=== measurement ===
+[016_04_measure] 1
+[016_04_x] 18.5
+[016_04_y] 51
+== calibration ==
+[016_04_cal-mode] DO
+[016_04_temp-comp] 1
+[016_04_temp_min] 20
+[016_04_temp_max] 40
+[016_04_k0_m] -0.05315
+[016_04_k0_a] 74.85616667
+[016_04_k100_m] -0.235033333
+[016_04_k100_a] 48.59816667
+=== measurement ===
+[016_05_measure] 1
+[016_05_x] 15.5
+[016_05_y] 49.5
+== calibration ==
+[016_05_cal-mode] NONE
+=== measurement ===
+[016_06_measure] 1
+[016_06_x] 15.5
+[016_06_y] 49.5
+== calibration ==
+[016_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[016_ph] 1
+[016_ph_max_valve_open] 3428.57142857143
+[016_ph_min_valve_open] 28.5714285714286
+[016_ph_p_band_value] 1
+[016_ph_integrator] 1
+[016_ph_buffering_capacity] MEDIUM
+[016_no_ph_sp] 1
+[016_01_ph_tim] 0
+[016_01_ph_val] 6.6
+[016_ph_sgnl] 3
+[016_ph_sgnl_cal] 1
+[016_ph_src_acid] B01
+[016_ph_src_base] A01
+[016_ph_act] 0
+= 1.feed control =
+[016_1_feed] 0
+= 2.feed control =
+[016_2_feed] 0
+===== fermentation =====
+[017_well] E01
+[017_content] X17
+[017_description]
+[017_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[017_01_measure] 1
+[017_01_x] 15.5
+[017_01_y] 62.5
+== calibration ==
+[017_01_cal-mode] NONE
+=== measurement ===
+[017_02_measure] 1
+[017_02_x] 15.5
+[017_02_y] 62.5
+== calibration ==
+[017_02_cal-mode] NONE
+=== measurement ===
+[017_03_measure] 1
+[017_03_x] 19.5
+[017_03_y] 59.5
+== calibration ==
+[017_03_cal-mode] PH
+[017_03_temp-comp] 1
+[017_03_temp_min] 20
+[017_03_temp_max] 40
+[017_03_fmin_a] 66.90742
+[017_03_fmin_m] -0.08812
+[017_03_fmax_a] 14.60001
+[017_03_fmax_m] -4E-05
+[017_03_ph0_a] 6.51001
+[017_03_ph0_m] -0.01053
+[017_03_dph_a] 0.59142
+[017_03_dph_m] -0.00083
+=== measurement ===
+[017_04_measure] 1
+[017_04_x] 18.5
+[017_04_y] 64
+== calibration ==
+[017_04_cal-mode] DO
+[017_04_temp-comp] 1
+[017_04_temp_min] 20
+[017_04_temp_max] 40
+[017_04_k0_m] -0.05315
+[017_04_k0_a] 74.85616667
+[017_04_k100_m] -0.235033333
+[017_04_k100_a] 48.59816667
+=== measurement ===
+[017_05_measure] 1
+[017_05_x] 15.5
+[017_05_y] 62.5
+== calibration ==
+[017_05_cal-mode] NONE
+=== measurement ===
+[017_06_measure] 1
+[017_06_x] 15.5
+[017_06_y] 62.5
+== calibration ==
+[017_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[017_ph] 1
+[017_ph_max_valve_open] 3428.57142857143
+[017_ph_min_valve_open] 28.5714285714286
+[017_ph_p_band_value] 1
+[017_ph_integrator] 1
+[017_ph_buffering_capacity] MEDIUM
+[017_no_ph_sp] 1
+[017_01_ph_tim] 0
+[017_01_ph_val] 6.6
+[017_ph_sgnl] 3
+[017_ph_sgnl_cal] 1
+[017_ph_src_acid] B01
+[017_ph_src_base] A01
+[017_ph_act] 0
+= 1.feed control =
+[017_1_feed] 0
+= 2.feed control =
+[017_2_feed] 0
+===== fermentation =====
+[018_well] E02
+[018_content] X18
+[018_description]
+[018_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[018_01_measure] 1
+[018_01_x] 28.5
+[018_01_y] 62.5
+== calibration ==
+[018_01_cal-mode] NONE
+=== measurement ===
+[018_02_measure] 1
+[018_02_x] 28.5
+[018_02_y] 62.5
+== calibration ==
+[018_02_cal-mode] NONE
+=== measurement ===
+[018_03_measure] 1
+[018_03_x] 32.5
+[018_03_y] 59.5
+== calibration ==
+[018_03_cal-mode] PH
+[018_03_temp-comp] 1
+[018_03_temp_min] 20
+[018_03_temp_max] 40
+[018_03_fmin_a] 66.90742
+[018_03_fmin_m] -0.08812
+[018_03_fmax_a] 14.60001
+[018_03_fmax_m] -4E-05
+[018_03_ph0_a] 6.51001
+[018_03_ph0_m] -0.01053
+[018_03_dph_a] 0.59142
+[018_03_dph_m] -0.00083
+=== measurement ===
+[018_04_measure] 1
+[018_04_x] 31.5
+[018_04_y] 64
+== calibration ==
+[018_04_cal-mode] DO
+[018_04_temp-comp] 1
+[018_04_temp_min] 20
+[018_04_temp_max] 40
+[018_04_k0_m] -0.05315
+[018_04_k0_a] 74.85616667
+[018_04_k100_m] -0.235033333
+[018_04_k100_a] 48.59816667
+=== measurement ===
+[018_05_measure] 1
+[018_05_x] 28.5
+[018_05_y] 62.5
+== calibration ==
+[018_05_cal-mode] NONE
+=== measurement ===
+[018_06_measure] 1
+[018_06_x] 28.5
+[018_06_y] 62.5
+== calibration ==
+[018_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[018_ph] 1
+[018_ph_max_valve_open] 3428.57142857143
+[018_ph_min_valve_open] 28.5714285714286
+[018_ph_p_band_value] 1
+[018_ph_integrator] 1
+[018_ph_buffering_capacity] MEDIUM
+[018_no_ph_sp] 1
+[018_01_ph_tim] 0
+[018_01_ph_val] 6.6
+[018_ph_sgnl] 3
+[018_ph_sgnl_cal] 1
+[018_ph_src_acid] B02
+[018_ph_src_base] A02
+[018_ph_act] 0
+= 1.feed control =
+[018_1_feed] 0
+= 2.feed control =
+[018_2_feed] 0
+===== fermentation =====
+[019_well] E03
+[019_content] X19
+[019_description]
+[019_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[019_01_measure] 1
+[019_01_x] 41.5
+[019_01_y] 62.5
+== calibration ==
+[019_01_cal-mode] NONE
+=== measurement ===
+[019_02_measure] 1
+[019_02_x] 41.5
+[019_02_y] 62.5
+== calibration ==
+[019_02_cal-mode] NONE
+=== measurement ===
+[019_03_measure] 1
+[019_03_x] 45.5
+[019_03_y] 59.5
+== calibration ==
+[019_03_cal-mode] PH
+[019_03_temp-comp] 1
+[019_03_temp_min] 20
+[019_03_temp_max] 40
+[019_03_fmin_a] 66.90742
+[019_03_fmin_m] -0.08812
+[019_03_fmax_a] 14.60001
+[019_03_fmax_m] -4E-05
+[019_03_ph0_a] 6.51001
+[019_03_ph0_m] -0.01053
+[019_03_dph_a] 0.59142
+[019_03_dph_m] -0.00083
+=== measurement ===
+[019_04_measure] 1
+[019_04_x] 44.5
+[019_04_y] 64
+== calibration ==
+[019_04_cal-mode] DO
+[019_04_temp-comp] 1
+[019_04_temp_min] 20
+[019_04_temp_max] 40
+[019_04_k0_m] -0.05315
+[019_04_k0_a] 74.85616667
+[019_04_k100_m] -0.235033333
+[019_04_k100_a] 48.59816667
+=== measurement ===
+[019_05_measure] 1
+[019_05_x] 41.5
+[019_05_y] 62.5
+== calibration ==
+[019_05_cal-mode] NONE
+=== measurement ===
+[019_06_measure] 1
+[019_06_x] 41.5
+[019_06_y] 62.5
+== calibration ==
+[019_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[019_ph] 1
+[019_ph_max_valve_open] 3428.57142857143
+[019_ph_min_valve_open] 28.5714285714286
+[019_ph_p_band_value] 1
+[019_ph_integrator] 1
+[019_ph_buffering_capacity] MEDIUM
+[019_no_ph_sp] 1
+[019_01_ph_tim] 0
+[019_01_ph_val] 6.6
+[019_ph_sgnl] 3
+[019_ph_sgnl_cal] 1
+[019_ph_src_acid] B03
+[019_ph_src_base] A03
+[019_ph_act] 0
+= 1.feed control =
+[019_1_feed] 0
+= 2.feed control =
+[019_2_feed] 0
+===== fermentation =====
+[020_well] E04
+[020_content] X20
+[020_description]
+[020_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[020_01_measure] 1
+[020_01_x] 54.5
+[020_01_y] 62.5
+== calibration ==
+[020_01_cal-mode] NONE
+=== measurement ===
+[020_02_measure] 1
+[020_02_x] 54.5
+[020_02_y] 62.5
+== calibration ==
+[020_02_cal-mode] NONE
+=== measurement ===
+[020_03_measure] 1
+[020_03_x] 58.5
+[020_03_y] 59.5
+== calibration ==
+[020_03_cal-mode] PH
+[020_03_temp-comp] 1
+[020_03_temp_min] 20
+[020_03_temp_max] 40
+[020_03_fmin_a] 66.90742
+[020_03_fmin_m] -0.08812
+[020_03_fmax_a] 14.60001
+[020_03_fmax_m] -4E-05
+[020_03_ph0_a] 6.51001
+[020_03_ph0_m] -0.01053
+[020_03_dph_a] 0.59142
+[020_03_dph_m] -0.00083
+=== measurement ===
+[020_04_measure] 1
+[020_04_x] 57.5
+[020_04_y] 64
+== calibration ==
+[020_04_cal-mode] DO
+[020_04_temp-comp] 1
+[020_04_temp_min] 20
+[020_04_temp_max] 40
+[020_04_k0_m] -0.05315
+[020_04_k0_a] 74.85616667
+[020_04_k100_m] -0.235033333
+[020_04_k100_a] 48.59816667
+=== measurement ===
+[020_05_measure] 1
+[020_05_x] 54.5
+[020_05_y] 62.5
+== calibration ==
+[020_05_cal-mode] NONE
+=== measurement ===
+[020_06_measure] 1
+[020_06_x] 54.5
+[020_06_y] 62.5
+== calibration ==
+[020_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[020_ph] 1
+[020_ph_max_valve_open] 3428.57142857143
+[020_ph_min_valve_open] 28.5714285714286
+[020_ph_p_band_value] 1
+[020_ph_integrator] 1
+[020_ph_buffering_capacity] MEDIUM
+[020_no_ph_sp] 1
+[020_01_ph_tim] 0
+[020_01_ph_val] 6.6
+[020_ph_sgnl] 3
+[020_ph_sgnl_cal] 1
+[020_ph_src_acid] B04
+[020_ph_src_base] A04
+[020_ph_act] 0
+= 1.feed control =
+[020_1_feed] 0
+= 2.feed control =
+[020_2_feed] 0
+===== fermentation =====
+[021_well] E05
+[021_content] X21
+[021_description]
+[021_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[021_01_measure] 1
+[021_01_x] 67.5
+[021_01_y] 62.5
+== calibration ==
+[021_01_cal-mode] NONE
+=== measurement ===
+[021_02_measure] 1
+[021_02_x] 67.5
+[021_02_y] 62.5
+== calibration ==
+[021_02_cal-mode] NONE
+=== measurement ===
+[021_03_measure] 1
+[021_03_x] 71.5
+[021_03_y] 59.5
+== calibration ==
+[021_03_cal-mode] PH
+[021_03_temp-comp] 1
+[021_03_temp_min] 20
+[021_03_temp_max] 40
+[021_03_fmin_a] 66.90742
+[021_03_fmin_m] -0.08812
+[021_03_fmax_a] 14.60001
+[021_03_fmax_m] -4E-05
+[021_03_ph0_a] 6.51001
+[021_03_ph0_m] -0.01053
+[021_03_dph_a] 0.59142
+[021_03_dph_m] -0.00083
+=== measurement ===
+[021_04_measure] 1
+[021_04_x] 70.5
+[021_04_y] 64
+== calibration ==
+[021_04_cal-mode] DO
+[021_04_temp-comp] 1
+[021_04_temp_min] 20
+[021_04_temp_max] 40
+[021_04_k0_m] -0.05315
+[021_04_k0_a] 74.85616667
+[021_04_k100_m] -0.235033333
+[021_04_k100_a] 48.59816667
+=== measurement ===
+[021_05_measure] 1
+[021_05_x] 67.5
+[021_05_y] 62.5
+== calibration ==
+[021_05_cal-mode] NONE
+=== measurement ===
+[021_06_measure] 1
+[021_06_x] 67.5
+[021_06_y] 62.5
+== calibration ==
+[021_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[021_ph] 1
+[021_ph_max_valve_open] 3428.57142857143
+[021_ph_min_valve_open] 28.5714285714286
+[021_ph_p_band_value] 1
+[021_ph_integrator] 1
+[021_ph_buffering_capacity] MEDIUM
+[021_no_ph_sp] 1
+[021_01_ph_tim] 0
+[021_01_ph_val] 6.6
+[021_ph_sgnl] 3
+[021_ph_sgnl_cal] 1
+[021_ph_src_acid] B05
+[021_ph_src_base] A05
+[021_ph_act] 0
+= 1.feed control =
+[021_1_feed] 0
+= 2.feed control =
+[021_2_feed] 0
+===== fermentation =====
+[022_well] E06
+[022_content] X22
+[022_description]
+[022_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[022_01_measure] 1
+[022_01_x] 80.5
+[022_01_y] 62.5
+== calibration ==
+[022_01_cal-mode] NONE
+=== measurement ===
+[022_02_measure] 1
+[022_02_x] 80.5
+[022_02_y] 62.5
+== calibration ==
+[022_02_cal-mode] NONE
+=== measurement ===
+[022_03_measure] 1
+[022_03_x] 84.5
+[022_03_y] 59.5
+== calibration ==
+[022_03_cal-mode] PH
+[022_03_temp-comp] 1
+[022_03_temp_min] 20
+[022_03_temp_max] 40
+[022_03_fmin_a] 66.90742
+[022_03_fmin_m] -0.08812
+[022_03_fmax_a] 14.60001
+[022_03_fmax_m] -4E-05
+[022_03_ph0_a] 6.51001
+[022_03_ph0_m] -0.01053
+[022_03_dph_a] 0.59142
+[022_03_dph_m] -0.00083
+=== measurement ===
+[022_04_measure] 1
+[022_04_x] 83.5
+[022_04_y] 64
+== calibration ==
+[022_04_cal-mode] DO
+[022_04_temp-comp] 1
+[022_04_temp_min] 20
+[022_04_temp_max] 40
+[022_04_k0_m] -0.05315
+[022_04_k0_a] 74.85616667
+[022_04_k100_m] -0.235033333
+[022_04_k100_a] 48.59816667
+=== measurement ===
+[022_05_measure] 1
+[022_05_x] 80.5
+[022_05_y] 62.5
+== calibration ==
+[022_05_cal-mode] NONE
+=== measurement ===
+[022_06_measure] 1
+[022_06_x] 80.5
+[022_06_y] 62.5
+== calibration ==
+[022_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[022_ph] 1
+[022_ph_max_valve_open] 3428.57142857143
+[022_ph_min_valve_open] 28.5714285714286
+[022_ph_p_band_value] 1
+[022_ph_integrator] 1
+[022_ph_buffering_capacity] MEDIUM
+[022_no_ph_sp] 1
+[022_01_ph_tim] 0
+[022_01_ph_val] 6.6
+[022_ph_sgnl] 3
+[022_ph_sgnl_cal] 1
+[022_ph_src_acid] B06
+[022_ph_src_base] A06
+[022_ph_act] 0
+= 1.feed control =
+[022_1_feed] 0
+= 2.feed control =
+[022_2_feed] 0
+===== fermentation =====
+[023_well] E07
+[023_content] X23
+[023_description]
+[023_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[023_01_measure] 1
+[023_01_x] 93.5
+[023_01_y] 62.5
+== calibration ==
+[023_01_cal-mode] NONE
+=== measurement ===
+[023_02_measure] 1
+[023_02_x] 93.5
+[023_02_y] 62.5
+== calibration ==
+[023_02_cal-mode] NONE
+=== measurement ===
+[023_03_measure] 1
+[023_03_x] 97.5
+[023_03_y] 59.5
+== calibration ==
+[023_03_cal-mode] PH
+[023_03_temp-comp] 1
+[023_03_temp_min] 20
+[023_03_temp_max] 40
+[023_03_fmin_a] 66.90742
+[023_03_fmin_m] -0.08812
+[023_03_fmax_a] 14.60001
+[023_03_fmax_m] -4E-05
+[023_03_ph0_a] 6.51001
+[023_03_ph0_m] -0.01053
+[023_03_dph_a] 0.59142
+[023_03_dph_m] -0.00083
+=== measurement ===
+[023_04_measure] 1
+[023_04_x] 96.5
+[023_04_y] 64
+== calibration ==
+[023_04_cal-mode] DO
+[023_04_temp-comp] 1
+[023_04_temp_min] 20
+[023_04_temp_max] 40
+[023_04_k0_m] -0.05315
+[023_04_k0_a] 74.85616667
+[023_04_k100_m] -0.235033333
+[023_04_k100_a] 48.59816667
+=== measurement ===
+[023_05_measure] 1
+[023_05_x] 93.5
+[023_05_y] 62.5
+== calibration ==
+[023_05_cal-mode] NONE
+=== measurement ===
+[023_06_measure] 1
+[023_06_x] 93.5
+[023_06_y] 62.5
+== calibration ==
+[023_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[023_ph] 1
+[023_ph_max_valve_open] 3428.57142857143
+[023_ph_min_valve_open] 28.5714285714286
+[023_ph_p_band_value] 1
+[023_ph_integrator] 1
+[023_ph_buffering_capacity] MEDIUM
+[023_no_ph_sp] 1
+[023_01_ph_tim] 0
+[023_01_ph_val] 6.6
+[023_ph_sgnl] 3
+[023_ph_sgnl_cal] 1
+[023_ph_src_acid] B07
+[023_ph_src_base] A07
+[023_ph_act] 0
+= 1.feed control =
+[023_1_feed] 0
+= 2.feed control =
+[023_2_feed] 0
+===== fermentation =====
+[024_well] E08
+[024_content] X24
+[024_description]
+[024_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[024_01_measure] 1
+[024_01_x] 106.5
+[024_01_y] 62.5
+== calibration ==
+[024_01_cal-mode] NONE
+=== measurement ===
+[024_02_measure] 1
+[024_02_x] 106.5
+[024_02_y] 62.5
+== calibration ==
+[024_02_cal-mode] NONE
+=== measurement ===
+[024_03_measure] 1
+[024_03_x] 110.5
+[024_03_y] 59.5
+== calibration ==
+[024_03_cal-mode] PH
+[024_03_temp-comp] 1
+[024_03_temp_min] 20
+[024_03_temp_max] 40
+[024_03_fmin_a] 66.90742
+[024_03_fmin_m] -0.08812
+[024_03_fmax_a] 14.60001
+[024_03_fmax_m] -4E-05
+[024_03_ph0_a] 6.51001
+[024_03_ph0_m] -0.01053
+[024_03_dph_a] 0.59142
+[024_03_dph_m] -0.00083
+=== measurement ===
+[024_04_measure] 1
+[024_04_x] 109.5
+[024_04_y] 64
+== calibration ==
+[024_04_cal-mode] DO
+[024_04_temp-comp] 1
+[024_04_temp_min] 20
+[024_04_temp_max] 40
+[024_04_k0_m] -0.05315
+[024_04_k0_a] 74.85616667
+[024_04_k100_m] -0.235033333
+[024_04_k100_a] 48.59816667
+=== measurement ===
+[024_05_measure] 1
+[024_05_x] 106.5
+[024_05_y] 62.5
+== calibration ==
+[024_05_cal-mode] NONE
+=== measurement ===
+[024_06_measure] 1
+[024_06_x] 106.5
+[024_06_y] 62.5
+== calibration ==
+[024_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[024_ph] 1
+[024_ph_max_valve_open] 3428.57142857143
+[024_ph_min_valve_open] 28.5714285714286
+[024_ph_p_band_value] 1
+[024_ph_integrator] 1
+[024_ph_buffering_capacity] MEDIUM
+[024_no_ph_sp] 1
+[024_01_ph_tim] 0
+[024_01_ph_val] 6.6
+[024_ph_sgnl] 3
+[024_ph_sgnl_cal] 1
+[024_ph_src_acid] B08
+[024_ph_src_base] A08
+[024_ph_act] 0
+= 1.feed control =
+[024_1_feed] 0
+= 2.feed control =
+[024_2_feed] 0
+===== fermentation =====
+[025_well] F08
+[025_content] X32
+[025_description]
+[025_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[025_01_measure] 1
+[025_01_x] 106.5
+[025_01_y] 75.5
+== calibration ==
+[025_01_cal-mode] NONE
+=== measurement ===
+[025_02_measure] 1
+[025_02_x] 106.5
+[025_02_y] 75.5
+== calibration ==
+[025_02_cal-mode] NONE
+=== measurement ===
+[025_03_measure] 1
+[025_03_x] 110.5
+[025_03_y] 72.5
+== calibration ==
+[025_03_cal-mode] PH
+[025_03_temp-comp] 1
+[025_03_temp_min] 20
+[025_03_temp_max] 40
+[025_03_fmin_a] 66.90742
+[025_03_fmin_m] -0.08812
+[025_03_fmax_a] 14.60001
+[025_03_fmax_m] -4E-05
+[025_03_ph0_a] 6.51001
+[025_03_ph0_m] -0.01053
+[025_03_dph_a] 0.59142
+[025_03_dph_m] -0.00083
+=== measurement ===
+[025_04_measure] 1
+[025_04_x] 109.5
+[025_04_y] 77
+== calibration ==
+[025_04_cal-mode] DO
+[025_04_temp-comp] 1
+[025_04_temp_min] 20
+[025_04_temp_max] 40
+[025_04_k0_m] -0.05315
+[025_04_k0_a] 74.85616667
+[025_04_k100_m] -0.235033333
+[025_04_k100_a] 48.59816667
+=== measurement ===
+[025_05_measure] 1
+[025_05_x] 106.5
+[025_05_y] 75.5
+== calibration ==
+[025_05_cal-mode] NONE
+=== measurement ===
+[025_06_measure] 1
+[025_06_x] 106.5
+[025_06_y] 75.5
+== calibration ==
+[025_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[025_ph] 1
+[025_ph_max_valve_open] 3428.57142857143
+[025_ph_min_valve_open] 28.5714285714286
+[025_ph_p_band_value] 1
+[025_ph_integrator] 1
+[025_ph_buffering_capacity] MEDIUM
+[025_no_ph_sp] 1
+[025_01_ph_tim] 0
+[025_01_ph_val] 6.6
+[025_ph_sgnl] 3
+[025_ph_sgnl_cal] 1
+[025_ph_src_acid] B08
+[025_ph_src_base] A08
+[025_ph_act] 0
+= 1.feed control =
+[025_1_feed] 0
+= 2.feed control =
+[025_2_feed] 0
+===== fermentation =====
+[026_well] F07
+[026_content] X31
+[026_description]
+[026_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[026_01_measure] 1
+[026_01_x] 93.5
+[026_01_y] 75.5
+== calibration ==
+[026_01_cal-mode] NONE
+=== measurement ===
+[026_02_measure] 1
+[026_02_x] 93.5
+[026_02_y] 75.5
+== calibration ==
+[026_02_cal-mode] NONE
+=== measurement ===
+[026_03_measure] 1
+[026_03_x] 97.5
+[026_03_y] 72.5
+== calibration ==
+[026_03_cal-mode] PH
+[026_03_temp-comp] 1
+[026_03_temp_min] 20
+[026_03_temp_max] 40
+[026_03_fmin_a] 66.90742
+[026_03_fmin_m] -0.08812
+[026_03_fmax_a] 14.60001
+[026_03_fmax_m] -4E-05
+[026_03_ph0_a] 6.51001
+[026_03_ph0_m] -0.01053
+[026_03_dph_a] 0.59142
+[026_03_dph_m] -0.00083
+=== measurement ===
+[026_04_measure] 1
+[026_04_x] 96.5
+[026_04_y] 77
+== calibration ==
+[026_04_cal-mode] DO
+[026_04_temp-comp] 1
+[026_04_temp_min] 20
+[026_04_temp_max] 40
+[026_04_k0_m] -0.05315
+[026_04_k0_a] 74.85616667
+[026_04_k100_m] -0.235033333
+[026_04_k100_a] 48.59816667
+=== measurement ===
+[026_05_measure] 1
+[026_05_x] 93.5
+[026_05_y] 75.5
+== calibration ==
+[026_05_cal-mode] NONE
+=== measurement ===
+[026_06_measure] 1
+[026_06_x] 93.5
+[026_06_y] 75.5
+== calibration ==
+[026_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[026_ph] 1
+[026_ph_max_valve_open] 3428.57142857143
+[026_ph_min_valve_open] 28.5714285714286
+[026_ph_p_band_value] 1
+[026_ph_integrator] 1
+[026_ph_buffering_capacity] MEDIUM
+[026_no_ph_sp] 1
+[026_01_ph_tim] 0
+[026_01_ph_val] 6.6
+[026_ph_sgnl] 3
+[026_ph_sgnl_cal] 1
+[026_ph_src_acid] B07
+[026_ph_src_base] A07
+[026_ph_act] 0
+= 1.feed control =
+[026_1_feed] 0
+= 2.feed control =
+[026_2_feed] 0
+===== fermentation =====
+[027_well] F06
+[027_content] X30
+[027_description]
+[027_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[027_01_measure] 1
+[027_01_x] 80.5
+[027_01_y] 75.5
+== calibration ==
+[027_01_cal-mode] NONE
+=== measurement ===
+[027_02_measure] 1
+[027_02_x] 80.5
+[027_02_y] 75.5
+== calibration ==
+[027_02_cal-mode] NONE
+=== measurement ===
+[027_03_measure] 1
+[027_03_x] 84.5
+[027_03_y] 72.5
+== calibration ==
+[027_03_cal-mode] PH
+[027_03_temp-comp] 1
+[027_03_temp_min] 20
+[027_03_temp_max] 40
+[027_03_fmin_a] 66.90742
+[027_03_fmin_m] -0.08812
+[027_03_fmax_a] 14.60001
+[027_03_fmax_m] -4E-05
+[027_03_ph0_a] 6.51001
+[027_03_ph0_m] -0.01053
+[027_03_dph_a] 0.59142
+[027_03_dph_m] -0.00083
+=== measurement ===
+[027_04_measure] 1
+[027_04_x] 83.5
+[027_04_y] 77
+== calibration ==
+[027_04_cal-mode] DO
+[027_04_temp-comp] 1
+[027_04_temp_min] 20
+[027_04_temp_max] 40
+[027_04_k0_m] -0.05315
+[027_04_k0_a] 74.85616667
+[027_04_k100_m] -0.235033333
+[027_04_k100_a] 48.59816667
+=== measurement ===
+[027_05_measure] 1
+[027_05_x] 80.5
+[027_05_y] 75.5
+== calibration ==
+[027_05_cal-mode] NONE
+=== measurement ===
+[027_06_measure] 1
+[027_06_x] 80.5
+[027_06_y] 75.5
+== calibration ==
+[027_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[027_ph] 1
+[027_ph_max_valve_open] 3428.57142857143
+[027_ph_min_valve_open] 28.5714285714286
+[027_ph_p_band_value] 1
+[027_ph_integrator] 1
+[027_ph_buffering_capacity] MEDIUM
+[027_no_ph_sp] 1
+[027_01_ph_tim] 0
+[027_01_ph_val] 6.6
+[027_ph_sgnl] 3
+[027_ph_sgnl_cal] 1
+[027_ph_src_acid] B06
+[027_ph_src_base] A06
+[027_ph_act] 0
+= 1.feed control =
+[027_1_feed] 0
+= 2.feed control =
+[027_2_feed] 0
+===== fermentation =====
+[028_well] F05
+[028_content] X29
+[028_description]
+[028_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[028_01_measure] 1
+[028_01_x] 67.5
+[028_01_y] 75.5
+== calibration ==
+[028_01_cal-mode] NONE
+=== measurement ===
+[028_02_measure] 1
+[028_02_x] 67.5
+[028_02_y] 75.5
+== calibration ==
+[028_02_cal-mode] NONE
+=== measurement ===
+[028_03_measure] 1
+[028_03_x] 71.5
+[028_03_y] 72.5
+== calibration ==
+[028_03_cal-mode] PH
+[028_03_temp-comp] 1
+[028_03_temp_min] 20
+[028_03_temp_max] 40
+[028_03_fmin_a] 66.90742
+[028_03_fmin_m] -0.08812
+[028_03_fmax_a] 14.60001
+[028_03_fmax_m] -4E-05
+[028_03_ph0_a] 6.51001
+[028_03_ph0_m] -0.01053
+[028_03_dph_a] 0.59142
+[028_03_dph_m] -0.00083
+=== measurement ===
+[028_04_measure] 1
+[028_04_x] 70.5
+[028_04_y] 77
+== calibration ==
+[028_04_cal-mode] DO
+[028_04_temp-comp] 1
+[028_04_temp_min] 20
+[028_04_temp_max] 40
+[028_04_k0_m] -0.05315
+[028_04_k0_a] 74.85616667
+[028_04_k100_m] -0.235033333
+[028_04_k100_a] 48.59816667
+=== measurement ===
+[028_05_measure] 1
+[028_05_x] 67.5
+[028_05_y] 75.5
+== calibration ==
+[028_05_cal-mode] NONE
+=== measurement ===
+[028_06_measure] 1
+[028_06_x] 67.5
+[028_06_y] 75.5
+== calibration ==
+[028_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[028_ph] 1
+[028_ph_max_valve_open] 3428.57142857143
+[028_ph_min_valve_open] 28.5714285714286
+[028_ph_p_band_value] 1
+[028_ph_integrator] 1
+[028_ph_buffering_capacity] MEDIUM
+[028_no_ph_sp] 1
+[028_01_ph_tim] 0
+[028_01_ph_val] 6.6
+[028_ph_sgnl] 3
+[028_ph_sgnl_cal] 1
+[028_ph_src_acid] B05
+[028_ph_src_base] A05
+[028_ph_act] 0
+= 1.feed control =
+[028_1_feed] 0
+= 2.feed control =
+[028_2_feed] 0
+===== fermentation =====
+[029_well] F04
+[029_content] X28
+[029_description]
+[029_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[029_01_measure] 1
+[029_01_x] 54.5
+[029_01_y] 75.5
+== calibration ==
+[029_01_cal-mode] NONE
+=== measurement ===
+[029_02_measure] 1
+[029_02_x] 54.5
+[029_02_y] 75.5
+== calibration ==
+[029_02_cal-mode] NONE
+=== measurement ===
+[029_03_measure] 1
+[029_03_x] 58.5
+[029_03_y] 72.5
+== calibration ==
+[029_03_cal-mode] PH
+[029_03_temp-comp] 1
+[029_03_temp_min] 20
+[029_03_temp_max] 40
+[029_03_fmin_a] 66.90742
+[029_03_fmin_m] -0.08812
+[029_03_fmax_a] 14.60001
+[029_03_fmax_m] -4E-05
+[029_03_ph0_a] 6.51001
+[029_03_ph0_m] -0.01053
+[029_03_dph_a] 0.59142
+[029_03_dph_m] -0.00083
+=== measurement ===
+[029_04_measure] 1
+[029_04_x] 57.5
+[029_04_y] 77
+== calibration ==
+[029_04_cal-mode] DO
+[029_04_temp-comp] 1
+[029_04_temp_min] 20
+[029_04_temp_max] 40
+[029_04_k0_m] -0.05315
+[029_04_k0_a] 74.85616667
+[029_04_k100_m] -0.235033333
+[029_04_k100_a] 48.59816667
+=== measurement ===
+[029_05_measure] 1
+[029_05_x] 54.5
+[029_05_y] 75.5
+== calibration ==
+[029_05_cal-mode] NONE
+=== measurement ===
+[029_06_measure] 1
+[029_06_x] 54.5
+[029_06_y] 75.5
+== calibration ==
+[029_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[029_ph] 1
+[029_ph_max_valve_open] 3428.57142857143
+[029_ph_min_valve_open] 28.5714285714286
+[029_ph_p_band_value] 1
+[029_ph_integrator] 1
+[029_ph_buffering_capacity] MEDIUM
+[029_no_ph_sp] 1
+[029_01_ph_tim] 0
+[029_01_ph_val] 6.6
+[029_ph_sgnl] 3
+[029_ph_sgnl_cal] 1
+[029_ph_src_acid] B04
+[029_ph_src_base] A04
+[029_ph_act] 0
+= 1.feed control =
+[029_1_feed] 0
+= 2.feed control =
+[029_2_feed] 0
+===== fermentation =====
+[030_well] F03
+[030_content] X27
+[030_description]
+[030_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[030_01_measure] 1
+[030_01_x] 41.5
+[030_01_y] 75.5
+== calibration ==
+[030_01_cal-mode] NONE
+=== measurement ===
+[030_02_measure] 1
+[030_02_x] 41.5
+[030_02_y] 75.5
+== calibration ==
+[030_02_cal-mode] NONE
+=== measurement ===
+[030_03_measure] 1
+[030_03_x] 45.5
+[030_03_y] 72.5
+== calibration ==
+[030_03_cal-mode] PH
+[030_03_temp-comp] 1
+[030_03_temp_min] 20
+[030_03_temp_max] 40
+[030_03_fmin_a] 66.90742
+[030_03_fmin_m] -0.08812
+[030_03_fmax_a] 14.60001
+[030_03_fmax_m] -4E-05
+[030_03_ph0_a] 6.51001
+[030_03_ph0_m] -0.01053
+[030_03_dph_a] 0.59142
+[030_03_dph_m] -0.00083
+=== measurement ===
+[030_04_measure] 1
+[030_04_x] 44.5
+[030_04_y] 77
+== calibration ==
+[030_04_cal-mode] DO
+[030_04_temp-comp] 1
+[030_04_temp_min] 20
+[030_04_temp_max] 40
+[030_04_k0_m] -0.05315
+[030_04_k0_a] 74.85616667
+[030_04_k100_m] -0.235033333
+[030_04_k100_a] 48.59816667
+=== measurement ===
+[030_05_measure] 1
+[030_05_x] 41.5
+[030_05_y] 75.5
+== calibration ==
+[030_05_cal-mode] NONE
+=== measurement ===
+[030_06_measure] 1
+[030_06_x] 41.5
+[030_06_y] 75.5
+== calibration ==
+[030_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[030_ph] 1
+[030_ph_max_valve_open] 3428.57142857143
+[030_ph_min_valve_open] 28.5714285714286
+[030_ph_p_band_value] 1
+[030_ph_integrator] 1
+[030_ph_buffering_capacity] MEDIUM
+[030_no_ph_sp] 1
+[030_01_ph_tim] 0
+[030_01_ph_val] 6.6
+[030_ph_sgnl] 3
+[030_ph_sgnl_cal] 1
+[030_ph_src_acid] B03
+[030_ph_src_base] A03
+[030_ph_act] 0
+= 1.feed control =
+[030_1_feed] 0
+= 2.feed control =
+[030_2_feed] 0
+===== fermentation =====
+[031_well] F02
+[031_content] X26
+[031_description]
+[031_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[031_01_measure] 1
+[031_01_x] 28.5
+[031_01_y] 75.5
+== calibration ==
+[031_01_cal-mode] NONE
+=== measurement ===
+[031_02_measure] 1
+[031_02_x] 28.5
+[031_02_y] 75.5
+== calibration ==
+[031_02_cal-mode] NONE
+=== measurement ===
+[031_03_measure] 1
+[031_03_x] 32.5
+[031_03_y] 72.5
+== calibration ==
+[031_03_cal-mode] PH
+[031_03_temp-comp] 1
+[031_03_temp_min] 20
+[031_03_temp_max] 40
+[031_03_fmin_a] 66.90742
+[031_03_fmin_m] -0.08812
+[031_03_fmax_a] 14.60001
+[031_03_fmax_m] -4E-05
+[031_03_ph0_a] 6.51001
+[031_03_ph0_m] -0.01053
+[031_03_dph_a] 0.59142
+[031_03_dph_m] -0.00083
+=== measurement ===
+[031_04_measure] 1
+[031_04_x] 31.5
+[031_04_y] 77
+== calibration ==
+[031_04_cal-mode] DO
+[031_04_temp-comp] 1
+[031_04_temp_min] 20
+[031_04_temp_max] 40
+[031_04_k0_m] -0.05315
+[031_04_k0_a] 74.85616667
+[031_04_k100_m] -0.235033333
+[031_04_k100_a] 48.59816667
+=== measurement ===
+[031_05_measure] 1
+[031_05_x] 28.5
+[031_05_y] 75.5
+== calibration ==
+[031_05_cal-mode] NONE
+=== measurement ===
+[031_06_measure] 1
+[031_06_x] 28.5
+[031_06_y] 75.5
+== calibration ==
+[031_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[031_ph] 1
+[031_ph_max_valve_open] 3428.57142857143
+[031_ph_min_valve_open] 28.5714285714286
+[031_ph_p_band_value] 1
+[031_ph_integrator] 1
+[031_ph_buffering_capacity] MEDIUM
+[031_no_ph_sp] 1
+[031_01_ph_tim] 0
+[031_01_ph_val] 6.6
+[031_ph_sgnl] 3
+[031_ph_sgnl_cal] 1
+[031_ph_src_acid] B02
+[031_ph_src_base] A02
+[031_ph_act] 0
+= 1.feed control =
+[031_1_feed] 0
+= 2.feed control =
+[031_2_feed] 0
+===== fermentation =====
+[032_well] F01
+[032_content] X25
+[032_description]
+[032_s_vol] 1000
+==== measurements ====
+=== measurement ===
+[032_01_measure] 1
+[032_01_x] 15.5
+[032_01_y] 75.5
+== calibration ==
+[032_01_cal-mode] NONE
+=== measurement ===
+[032_02_measure] 1
+[032_02_x] 15.5
+[032_02_y] 75.5
+== calibration ==
+[032_02_cal-mode] NONE
+=== measurement ===
+[032_03_measure] 1
+[032_03_x] 19.5
+[032_03_y] 72.5
+== calibration ==
+[032_03_cal-mode] PH
+[032_03_temp-comp] 1
+[032_03_temp_min] 20
+[032_03_temp_max] 40
+[032_03_fmin_a] 66.90742
+[032_03_fmin_m] -0.08812
+[032_03_fmax_a] 14.60001
+[032_03_fmax_m] -4E-05
+[032_03_ph0_a] 6.51001
+[032_03_ph0_m] -0.01053
+[032_03_dph_a] 0.59142
+[032_03_dph_m] -0.00083
+=== measurement ===
+[032_04_measure] 1
+[032_04_x] 18.5
+[032_04_y] 77
+== calibration ==
+[032_04_cal-mode] DO
+[032_04_temp-comp] 1
+[032_04_temp_min] 20
+[032_04_temp_max] 40
+[032_04_k0_m] -0.05315
+[032_04_k0_a] 74.85616667
+[032_04_k100_m] -0.235033333
+[032_04_k100_a] 48.59816667
+=== measurement ===
+[032_05_measure] 1
+[032_05_x] 15.5
+[032_05_y] 75.5
+== calibration ==
+[032_05_cal-mode] NONE
+=== measurement ===
+[032_06_measure] 1
+[032_06_x] 15.5
+[032_06_y] 75.5
+== calibration ==
+[032_06_cal-mode] NONE
+== microfluidics ==
+= pH control =
+[032_ph] 1
+[032_ph_max_valve_open] 3428.57142857143
+[032_ph_min_valve_open] 28.5714285714286
+[032_ph_p_band_value] 1
+[032_ph_integrator] 1
+[032_ph_buffering_capacity] MEDIUM
+[032_no_ph_sp] 1
+[032_01_ph_tim] 0
+[032_01_ph_val] 6.6
+[032_ph_sgnl] 3
+[032_ph_sgnl_cal] 1
+[032_ph_src_acid] B01
+[032_ph_src_base] A01
+[032_ph_act] 0
+= 1.feed control =
+[032_1_feed] 0
+= 2.feed control =
+[032_2_feed] 0
+[032_2_feed] 0
+=====data=====
+Type;Cycle;Well;Filterset;Time;Amp_1;Amp_2;AmpRef_1;AmpRef_2;Phase;Cal;T_UC_HumSensor_analog;T_LC_PT100;T_UC_PT100;O2;CO2;Humidity;Shaker;Service;User_Comment;Sys_Comment;Reservoir;MF_Volume;T_WB_heating_rod;T_144;T_180;T_181_1;T_192;P_UC_peltier;P_LC_peltier;P_WB_heating_rod;T_UC_HumSensor_digital;T_CO2;X-Pos;Y-Pos;T_LED;Ref_Int;Ref_Phase;Ref_Gain;Ch1-MP;Ch2-MF;Ch3-FA;Ch4-OP;Ch5-FB
+C;0001;;;16;;;;;;;;;;;;;;;;COVER CLOSED;;;
+C;0001;;;20;;;;;;;;;;;;;;;;START SHAKER;;;
+C;0001;;;20;;;;;;;;;;;;;;;;TEMP REGULATION ON;;;
+F;0000;001;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;016;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;017;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;032;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;002;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;015;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;018;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;031;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;003;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;014;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;019;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;030;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;004;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;013;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;020;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;029;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;005;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;012;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;021;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;028;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;006;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;011;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;022;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;027;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;007;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;010;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;023;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;026;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;008;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;009;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;024;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;025;;15;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0000;001;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;016;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;017;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;032;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;002;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;015;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;018;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;031;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;003;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;014;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;019;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;030;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;004;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;013;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;020;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;029;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;005;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;012;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;021;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;028;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;006;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;011;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;022;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;027;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;007;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;010;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;023;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;026;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;008;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;009;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;024;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0000;025;;15;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+P;0001;;;20;;;;;;;21.70;26.40;23.60;21.06;-9999.00;47.60;0;;;;;;25.70;30.60;29.01;27.81;0.00;0.00;0.00;0.00;23.45;-1000.00;-124.872;-69.560;0;;;;2.011;1.334;1.079;1.070;1.314;
+P;0001;;;21;;;;;;;21.70;26.40;23.60;21.06;-9999.00;47.60;0;;;;;;25.70;30.60;29.01;27.81;0.00;0.00;0.00;0.00;23.45;-1000.00;-124.872;-69.560;0;;;;2.012;1.335;1.079;1.070;1.314;
+R;0001;;01;52;216.48;0.00;;;;;22.30;27.40;24.00;21.03;-9999.00;55.02;1199;2928.06;;;;;25.90;30.80;24.41;27.94;0.00;100.00;95.50;80.00;23.52;-1000.00;-124.872;-69.560;30;2928.06;72.55;2;2.012
+M;0001;001;01;54;9.52;0.00;8.96;0.00;-2.85;0.00;22.40;27.50;24.00;21.02;-9999.00;54.81;1200;#;;;;;25.90;30.90;24.38;27.94;0.00;100.00;92.00;80.00;23.53;-1000.00;-103.408;-67.096;32;2932.41;72.56;2;2.012
+M;0001;002;01;55;9.32;0.00;8.77;0.00;-2.92;0.00;22.40;27.50;24.00;21.02;-9999.00;54.65;1199;;;;;;25.90;30.90;24.38;27.94;0.00;100.00;92.00;80.00;23.55;-1000.00;-90.400;-67.096;32;2928.23;72.56;2;2.012
+M;0001;003;01;57;9.44;0.00;8.88;0.00;-2.89;0.00;22.50;27.60;24.00;21.02;-9999.00;54.39;1199;;;;;;25.90;30.90;24.38;27.94;0.00;100.00;87.00;80.00;23.58;-1000.00;-77.408;-67.096;32;2927.35;72.57;2;2.012
+M;0001;004;01;58;9.44;0.00;8.88;0.00;-2.90;0.00;22.60;27.80;24.00;21.01;-9999.00;54.32;1199;;;;;;25.90;30.90;24.44;27.94;0.00;100.00;84.00;80.00;23.59;-1000.00;-64.408;-67.096;32;2926.59;72.57;2;2.012
+M;0001;005;01;59;9.55;0.00;8.98;0.00;-3.01;0.00;22.60;27.80;24.00;21.01;-9999.00;54.32;1200;;;;;;25.90;31.00;24.44;27.94;0.00;100.00;84.00;80.00;23.61;-1000.00;-51.400;-67.096;32;2925.48;72.57;2;2.012
+M;0001;006;01;61;9.61;0.00;9.04;0.00;-2.97;0.00;22.70;27.90;24.00;21.00;-9999.00;54.28;1200;;;;;;26.00;31.00;24.31;27.94;0.00;100.00;81.00;80.00;23.63;-1000.00;-38.408;-67.096;32;2924.29;72.57;2;2.012
+M;0001;007;01;62;9.49;0.00;8.92;0.00;-2.99;0.00;22.90;28.00;24.00;20.99;-9999.00;54.35;1200;;;;;;26.00;31.00;24.31;27.94;0.00;100.00;79.00;80.00;23.65;-1000.00;-25.400;-67.096;32;2923.99;72.57;2;2.012
+M;0001;008;01;63;11.30;0.00;10.63;0.00;-3.02;0.00;22.90;28.00;24.00;20.99;-9999.00;54.40;1200;;;;;;26.00;31.00;24.31;27.94;0.00;100.00;79.00;80.00;23.67;-1000.00;-12.408;-67.096;32;2924.67;72.58;2;2.012
+M;0001;009;01;64;9.75;0.00;9.17;0.00;-3.03;0.00;23.00;28.10;24.10;20.99;-9999.00;54.49;1200;;;;;;26.00;31.00;24.38;27.94;0.00;100.00;75.50;80.00;23.68;-1000.00;-12.408;-54.088;32;2923.19;72.58;2;2.012
+M;0001;010;01;66;10.47;0.00;9.85;0.00;-2.91;0.00;23.10;28.20;24.10;20.99;-9999.00;54.48;1200;;;;;;26.00;31.10;24.41;27.94;0.00;100.00;72.50;80.00;23.70;-1000.00;-25.376;-54.088;32;2922.36;72.58;2;2.012
+M;0001;011;01;67;9.83;0.00;9.24;0.00;-2.93;0.00;23.10;28.20;24.10;20.98;-9999.00;54.57;1199;;;;;;26.00;31.10;24.41;27.94;0.00;100.00;72.50;80.00;23.74;-1000.00;-38.384;-54.088;32;2921.18;72.58;2;2.012
+M;0001;012;01;68;10.49;0.00;9.86;0.00;-2.84;0.00;23.20;28.30;24.10;20.98;-9999.00;54.62;1199;;;;;;26.00;31.10;24.44;28.00;0.00;100.00;68.00;80.00;23.76;-1000.00;-51.376;-54.088;32;2920.27;72.58;2;2.012
+M;0001;013;01;70;10.61;0.00;9.97;0.00;-2.84;0.00;23.40;28.40;24.20;20.98;-9999.00;54.68;1199;;;;;;26.00;31.10;24.38;28.00;0.00;100.00;65.50;80.00;23.79;-1000.00;-64.376;-54.088;32;2919.26;72.58;2;2.012
+M;0001;014;01;71;9.88;0.00;9.29;0.00;-2.88;0.00;23.40;28.40;24.20;20.97;-9999.00;54.73;1200;;;;;;26.00;31.20;24.38;28.00;0.00;100.00;65.50;80.00;23.82;-1000.00;-77.376;-54.088;32;2919.50;72.59;2;2.012
+M;0001;015;01;72;9.88;0.00;9.29;0.00;-2.97;0.00;23.50;28.50;24.20;20.96;-9999.00;54.82;1200;;;;;;26.00;31.20;24.44;28.00;0.00;100.00;64.00;80.00;23.87;-1000.00;-90.360;-54.088;32;2919.71;72.59;2;2.012
+M;0001;016;01;74;9.99;0.00;9.40;0.00;-2.80;0.00;23.70;28.60;24.20;20.96;-9999.00;54.84;1199;;;;;;26.00;31.20;24.41;28.00;0.00;100.00;62.00;80.00;23.89;-1000.00;-103.376;-54.088;32;2920.63;72.59;2;2.012
+M;0001;017;01;75;10.65;0.00;10.02;0.00;-2.88;0.00;23.70;28.60;24.20;20.96;-9999.00;54.85;1199;;;;;;26.00;31.20;24.41;28.00;0.00;100.00;62.00;80.00;23.90;-1000.00;-103.376;-41.096;32;2919.24;72.59;2;2.012
+M;0001;018;01;76;10.13;0.00;9.53;0.00;-2.93;0.00;23.80;28.70;24.20;20.95;-9999.00;54.93;1200;;;;;;26.00;31.20;24.41;28.00;0.00;100.00;59.50;80.00;23.95;-1000.00;-90.400;-41.096;32;2916.45;72.59;2;2.012
+M;0001;019;01;78;11.11;0.00;10.45;0.00;-2.90;0.00;23.90;28.70;24.20;20.95;-9999.00;54.99;1200;;;;;;26.10;31.30;24.44;28.00;0.00;100.00;57.50;80.00;23.97;-1000.00;-77.408;-41.096;32;2917.52;72.59;2;2.012
+M;0001;020;01;79;10.01;0.00;9.41;0.00;-2.95;0.00;23.90;28.70;24.20;20.95;-9999.00;54.95;1199;;;;;;26.10;31.30;24.44;28.00;0.00;100.00;57.50;80.00;24.01;-1000.00;-64.408;-41.096;32;2915.65;72.60;2;2.012
+M;0001;021;01;80;10.25;0.00;9.64;0.00;-2.95;0.00;24.10;28.80;24.30;20.94;-9999.00;54.89;1199;;;;;;26.10;31.30;24.44;28.00;0.00;100.00;55.50;80.00;24.07;-1000.00;-51.400;-41.096;32;2915.43;72.60;2;2.012
+M;0001;022;01;82;9.83;0.00;9.24;0.00;-2.96;0.00;24.20;28.90;24.30;20.94;-9999.00;54.87;1199;;;;;;26.10;31.40;24.47;28.00;0.00;100.00;54.00;80.00;24.10;-1000.00;-38.408;-41.096;32;2914.32;72.60;2;2.012
+M;0001;023;01;83;10.57;0.00;9.94;0.00;-2.84;0.00;24.20;28.90;24.30;20.93;-9999.00;54.84;1200;;;;;;26.10;31.40;24.47;28.00;0.00;100.00;54.00;80.00;24.12;-1000.00;-25.400;-41.096;32;2913.94;72.61;2;2.012
+M;0001;024;01;84;10.13;0.00;9.52;0.00;-2.87;0.00;24.30;28.90;24.30;20.93;-9999.00;54.84;1200;;;;;;26.10;31.40;24.44;28.00;0.00;100.00;51.50;80.00;24.15;-1000.00;-12.408;-41.096;32;2912.60;72.60;2;2.012
+M;0001;025;01;86;10.68;0.00;10.04;0.00;-3.04;0.00;24.50;29.00;24.30;20.93;-9999.00;54.85;1199;;;;;;26.10;31.50;24.41;28.00;0.00;100.00;51.00;80.00;24.21;-1000.00;-12.408;-28.112;32;2914.31;72.60;2;2.012
+M;0001;026;01;87;10.65;0.00;10.01;0.00;-2.95;0.00;24.50;29.00;24.30;20.92;-9999.00;54.83;1200;;;;;;26.10;31.50;24.41;28.00;0.00;100.00;51.00;80.00;24.24;-1000.00;-25.368;-28.112;32;2913.25;72.60;2;2.012
+M;0001;027;01;88;9.78;0.00;9.20;0.00;-2.89;0.00;24.60;29.10;24.30;20.92;-9999.00;54.81;1200;;;;;;26.10;31.50;24.38;28.00;0.00;100.00;48.00;80.00;24.27;-1000.00;-38.384;-28.112;32;2913.62;72.61;2;2.012
+M;0001;028;01;90;10.21;0.00;9.60;0.00;-2.91;0.00;24.80;29.10;24.30;20.92;-9999.00;54.67;1200;;;;;;26.10;31.50;24.38;28.00;0.00;100.00;45.50;80.00;24.30;-1000.00;-51.376;-28.104;32;2914.17;72.61;2;2.012
+M;0001;029;01;91;10.55;0.00;9.92;0.00;-2.93;0.00;24.80;29.10;24.30;20.91;-9999.00;54.56;1200;;;;;;26.10;31.50;24.38;28.06;0.00;100.00;45.50;80.00;24.37;-1000.00;-64.376;-28.104;32;2914.59;72.60;2;2.012
+M;0001;030;01;92;10.59;0.00;9.96;0.00;-3.05;0.00;24.90;29.20;24.30;20.91;-9999.00;54.47;1200;;;;;;26.10;31.50;24.38;28.06;0.00;100.00;43.50;80.00;24.40;-1000.00;-77.376;-28.104;32;2913.82;72.61;2;2.012
+M;0001;031;01;94;9.94;0.00;9.35;0.00;-2.91;0.00;25.00;29.30;24.40;20.90;-9999.00;54.59;1198;;;;;;26.10;31.60;24.47;28.06;0.00;100.00;42.00;80.00;24.44;-1000.00;-90.360;-28.104;32;2914.38;72.61;2;2.012
+M;0001;032;01;95;10.18;0.00;9.58;0.00;-3.03;0.00;25.00;29.30;24.40;20.90;-9999.00;54.43;1199;;;;;;26.10;31.60;24.47;28.06;0.00;100.00;42.00;80.00;24.50;-1000.00;-103.376;-28.104;32;2915.88;72.61;2;2.012
+P;0001;;;95;;;;;;;25.00;29.30;24.40;20.90;-9999.00;54.43;1199;;;;;;26.10;31.60;24.47;28.06;0.00;100.00;42.00;80.00;24.50;-1000.00;-103.376;-28.104;32;;;;2.014;1.335;1.079;1.047;1.307;
+P;0001;;;95;;;;;;;25.00;29.30;24.40;20.90;-9999.00;54.43;1199;;;;;;26.10;31.60;24.47;28.06;0.00;100.00;42.00;80.00;24.50;-1000.00;-103.376;-28.104;0;;;;2.014;1.335;1.079;1.047;1.307;
+R;0001;;02;127;215.29;0.00;;;;;27.20;29.80;24.60;20.82;-9999.00;52.25;1199;2913.75;;;;;26.30;32.10;24.44;28.12;0.00;100.00;25.00;80.00;25.64;-1000.00;-124.864;-69.552;31;2913.75;72.64;2;2.014
+M;0001;001;02;129;38.30;0.00;36.22;0.00;-2.92;0.00;27.20;29.80;24.60;20.81;-9999.00;52.13;1199;#;;;;;26.30;32.10;24.34;28.12;0.00;100.00;25.00;80.00;25.68;-1000.00;-103.408;-67.096;33;2905.76;72.64;2;2.014
+M;0001;002;02;130;37.41;0.00;35.37;0.00;-2.93;0.00;27.30;29.80;24.60;20.81;-9999.00;51.97;1199;;;;;;26.30;32.10;24.41;28.12;0.00;95.50;24.50;80.00;25.75;-1000.00;-90.400;-67.096;33;2904.66;72.64;2;2.014
+M;0001;003;02;131;37.90;0.00;35.84;0.00;-2.93;0.00;27.50;29.80;24.60;20.81;-9999.00;51.86;1199;;;;;;26.30;32.20;24.41;28.12;0.00;92.50;24.00;80.00;25.79;-1000.00;-77.408;-67.096;33;2903.50;72.64;2;2.014
+M;0001;004;02;133;37.69;0.00;35.64;0.00;-2.93;0.00;27.60;29.80;24.60;20.80;-9999.00;51.74;1200;;;;;;26.40;32.20;24.41;28.12;0.00;89.50;24.00;80.00;25.82;-1000.00;-64.408;-67.096;33;2903.69;72.64;2;2.014
+M;0001;005;02;134;38.02;0.00;35.95;0.00;-2.89;0.00;27.60;29.80;24.60;20.80;-9999.00;51.70;1200;;;;;;26.40;32.20;24.41;28.12;0.00;89.50;24.00;80.00;25.86;-1000.00;-51.400;-67.096;33;2904.21;72.64;2;2.014
+M;0001;006;02;135;37.99;0.00;35.92;0.00;-2.93;0.00;27.70;29.80;24.60;20.80;-9999.00;51.65;1200;;;;;;26.40;32.30;24.41;28.12;0.00;86.00;23.50;80.00;25.92;-1000.00;-38.408;-67.096;33;2903.32;72.64;2;2.014
+M;0001;007;02;137;37.93;0.00;35.86;0.00;-2.92;0.00;27.80;29.80;24.60;20.79;-9999.00;51.58;1200;;;;;;26.40;32.30;24.44;28.19;0.00;84.00;24.00;80.00;25.96;-1000.00;-25.400;-67.096;33;2904.07;72.64;2;2.014
+M;0001;008;02;138;45.01;0.00;42.56;0.00;-2.95;0.00;27.80;29.80;24.60;20.79;-9999.00;51.53;1200;;;;;;26.40;32.30;24.38;28.19;0.00;84.00;24.00;80.00;26.00;-1000.00;-12.408;-67.096;33;2906.54;72.65;2;2.014
+M;0001;009;02;139;38.75;0.00;36.64;0.00;-2.94;0.00;27.90;29.80;24.60;20.79;-9999.00;51.39;1201;;;;;;26.40;32.30;24.38;28.19;0.00;81.00;23.50;80.00;26.08;-1000.00;-12.408;-54.088;33;2904.37;72.65;2;2.014
+M;0001;010;02;141;41.55;0.00;39.29;0.00;-2.93;0.00;28.00;29.90;24.70;20.78;-9999.00;51.32;1200;;;;;;26.40;32.30;24.44;28.19;0.00;78.00;23.00;80.00;26.12;-1000.00;-25.376;-54.088;33;2903.25;72.65;2;2.014
+M;0001;011;02;142;39.32;0.00;37.19;0.00;-2.94;0.00;28.00;29.90;24.70;20.78;-9999.00;51.25;1200;;;;;;26.40;32.30;24.44;28.19;0.00;78.00;23.00;80.00;26.17;-1000.00;-38.384;-54.088;33;2901.95;72.64;2;2.014
+M;0001;012;02;143;41.53;0.00;39.27;0.00;-2.90;0.00;28.10;29.90;24.70;20.78;-9999.00;51.10;1199;;;;;;26.40;32.40;24.44;28.19;0.00;75.50;22.50;80.00;26.24;-1000.00;-51.376;-54.088;33;2901.58;72.65;2;2.014
+M;0001;013;02;145;42.41;0.00;40.10;0.00;-2.93;0.00;28.10;29.90;24.70;20.77;-9999.00;50.98;1199;;;;;;26.40;32.40;24.38;28.19;0.00;75.50;22.50;80.00;26.27;-1000.00;-64.376;-54.088;33;2900.73;72.65;2;2.014
+M;0001;014;02;146;39.42;0.00;37.27;0.00;-2.91;0.00;28.20;29.90;24.70;20.77;-9999.00;50.90;1199;;;;;;26.40;32.40;24.41;28.19;0.00;73.00;22.00;80.00;26.31;-1000.00;-77.368;-54.088;33;2902.31;72.65;2;2.014
+M;0001;015;02;147;39.24;0.00;37.10;0.00;-2.93;0.00;28.30;29.90;24.70;20.77;-9999.00;50.82;1199;;;;;;26.40;32.40;24.41;28.19;0.00;70.00;22.00;80.00;26.35;-1000.00;-90.360;-54.088;33;2901.32;72.65;2;2.014
+M;0001;016;02;149;39.91;0.00;37.74;0.00;-2.91;0.00;28.30;29.90;24.70;20.77;-9999.00;50.67;1199;;;;;;26.40;32.40;24.50;28.19;0.00;70.00;22.00;80.00;26.42;-1000.00;-103.376;-54.088;33;2903.86;72.65;2;2.014
+M;0001;017;02;150;42.44;0.00;40.13;0.00;-2.93;0.00;28.40;29.90;24.70;20.76;-9999.00;50.60;1199;;;;;;26.40;32.50;24.34;28.19;0.00;67.00;22.50;80.00;26.46;-1000.00;-103.376;-41.096;33;2902.32;72.65;2;2.014
+M;0001;018;02;151;40.36;0.00;38.16;0.00;-2.92;0.00;28.50;29.90;24.70;20.76;-9999.00;50.52;1199;;;;;;26.40;32.50;24.34;28.19;0.00;64.50;22.00;80.00;26.49;-1000.00;-90.400;-41.096;33;2901.54;72.65;2;2.014
+M;0001;019;02;153;40.61;0.00;38.40;0.00;-2.89;0.00;28.60;29.90;24.70;20.76;-9999.00;50.35;1199;;;;;;26.50;32.50;24.38;28.19;0.00;62.00;22.00;80.00;26.56;-1000.00;-77.408;-41.096;33;2901.18;72.66;2;2.014
+M;0001;020;02;154;39.40;0.00;37.26;0.00;-2.90;0.00;28.60;29.90;24.70;20.76;-9999.00;50.29;1199;;;;;;26.50;32.50;24.44;28.19;0.00;62.00;22.00;80.00;26.60;-1000.00;-64.408;-41.096;33;2901.99;72.65;2;2.014
+M;0001;021;02;155;40.72;0.00;38.50;0.00;-2.93;0.00;28.70;29.90;24.70;20.75;-9999.00;50.19;1199;;;;;;26.50;32.50;24.44;28.19;0.00;59.00;22.00;80.00;26.64;-1000.00;-51.400;-41.096;33;2899.30;72.65;2;2.014
+M;0001;022;02;157;39.02;0.00;36.90;0.00;-2.91;0.00;28.80;29.90;24.80;20.75;-9999.00;49.96;1200;;;;;;26.50;32.50;24.41;28.19;0.00;57.50;22.00;80.00;26.68;-1000.00;-38.408;-41.096;33;2896.21;72.65;2;2.014
+M;0001;023;02;158;41.91;0.00;39.63;0.00;-2.93;0.00;28.80;29.90;24.80;20.75;-9999.00;49.83;1200;;;;;;26.50;32.60;24.44;28.19;0.00;57.50;22.00;80.00;26.76;-1000.00;-25.400;-41.096;33;2896.88;72.65;2;2.014
+M;0001;024;02;159;39.97;0.00;37.79;0.00;-2.95;0.00;28.90;29.90;24.80;20.75;-9999.00;49.76;1199;;;;;;26.50;32.60;24.44;28.19;0.00;55.50;22.50;80.00;26.78;-1000.00;-12.408;-41.096;33;2897.90;72.65;2;2.014
+M;0001;025;02;161;42.34;0.00;40.04;0.00;-2.93;0.00;28.90;29.90;24.80;20.74;-9999.00;49.69;1200;;;;;;26.50;32.60;24.47;28.19;0.00;52.50;22.00;80.00;26.81;-1000.00;-12.408;-28.112;33;2899.33;72.66;2;2.014
+M;0001;026;02;162;42.10;0.00;39.81;0.00;-2.90;0.00;28.90;29.90;24.80;20.74;-9999.00;49.54;1200;;;;;;26.50;32.60;24.44;28.19;0.00;52.50;22.00;80.00;26.88;-1000.00;-25.368;-28.112;33;2898.31;72.65;2;2.014
+M;0001;027;02;163;38.85;0.00;36.74;0.00;-2.94;0.00;29.00;29.90;24.80;20.73;-9999.00;49.51;1200;;;;;;26.50;32.60;24.44;28.25;0.00;50.00;22.00;80.00;26.91;-1000.00;-38.384;-28.112;33;2897.48;72.66;2;2.014
+M;0001;028;02;165;40.69;0.00;38.48;0.00;-2.92;0.00;29.10;29.90;24.80;20.73;-9999.00;49.46;1200;;;;;;26.50;32.60;24.41;28.19;0.00;48.50;21.50;80.00;26.95;-1000.00;-51.376;-28.112;33;2899.95;72.66;2;2.014
+M;0001;029;02;166;41.60;0.00;39.34;0.00;-2.92;0.00;29.10;29.90;24.80;20.73;-9999.00;49.37;1200;;;;;;26.50;32.60;24.41;28.19;0.00;48.50;21.50;80.00;27.00;-1000.00;-64.376;-28.112;33;2899.90;72.66;2;2.014
+M;0001;030;02;167;42.10;0.00;39.81;0.00;-2.90;0.00;29.20;29.90;24.80;20.72;-9999.00;49.31;1200;;;;;;26.50;32.70;24.41;28.25;0.00;46.00;21.50;80.00;27.04;-1000.00;-77.368;-28.112;33;2899.88;72.66;2;2.014
+M;0001;031;02;169;39.61;0.00;37.45;0.00;-2.89;0.00;29.20;29.90;24.80;20.72;-9999.00;49.24;1199;;;;;;26.50;32.70;24.47;28.25;0.00;43.50;21.50;80.00;27.07;-1000.00;-90.360;-28.112;33;2900.25;72.66;2;2.014
+M;0001;032;02;170;40.45;0.00;38.25;0.00;-2.90;0.00;29.20;29.90;24.80;20.72;-9999.00;49.19;1199;;;;;;26.50;32.70;24.44;28.25;0.00;43.50;21.50;80.00;27.11;-1000.00;-103.368;-28.112;33;2898.31;72.66;2;2.014
+P;0001;;;170;;;;;;;29.20;29.90;24.80;20.72;-9999.00;49.19;1199;;;;;;26.50;32.70;24.44;28.25;0.00;43.50;21.50;80.00;27.11;-1000.00;-103.368;-28.112;33;;;;2.013;1.333;1.080;1.046;1.322;
+P;0001;;;172;;;;;;;29.30;29.90;24.90;20.71;-9999.00;49.08;1199;;;;;;26.60;32.80;24.44;28.25;0.00;42.00;21.50;80.00;27.17;-1000.00;-103.368;-28.112;2;;;;2.014;1.334;1.080;1.047;1.324;
+M;0001;001;03;193;76.66;0.00;0.00;0.00;34.31;6.44;29.70;30.00;25.00;20.67;-9999.00;48.46;1199;;;;;;26.70;33.00;24.47;28.31;0.00;28.00;20.50;80.00;27.74;-1000.00;-99.408;-70.064;23;3486.20;71.95;4;2.014
+M;0001;002;03;195;79.49;0.00;0.00;0.00;33.95;6.45;29.70;30.00;25.00;20.67;-9999.00;48.43;1199;;;;;;26.70;33.00;24.41;28.31;0.00;27.00;19.50;80.00;27.76;-1000.00;-86.400;-70.064;23;3485.26;71.94;4;2.014
+M;0001;003;03;196;89.18;0.00;0.00;0.00;35.06;6.40;29.70;30.00;25.00;20.66;-9999.00;48.41;1199;;;;;;26.70;33.10;24.47;28.31;0.00;27.00;19.50;80.00;27.81;-1000.00;-73.408;-70.064;23;3484.91;71.95;4;2.014
+M;0001;004;03;197;85.60;0.00;0.00;0.00;34.85;6.41;29.80;30.00;25.10;20.66;-9999.00;48.43;1199;;;;;;26.70;33.10;24.47;28.31;0.00;26.00;18.50;80.00;27.83;-1000.00;-60.408;-70.064;23;3485.62;71.95;4;2.014
+M;0001;005;03;199;80.99;0.00;0.00;0.00;33.55;6.47;29.80;30.00;25.10;20.66;-9999.00;48.41;1199;;;;;;26.70;33.10;24.47;28.31;0.00;25.50;18.00;80.00;27.85;-1000.00;-47.400;-70.064;23;3484.15;71.96;4;2.014
+M;0001;006;03;200;84.27;0.00;0.00;0.00;34.80;6.41;29.80;30.00;25.10;20.66;-9999.00;48.44;1199;;;;;;26.70;33.10;24.41;28.31;0.00;25.00;17.50;80.00;27.89;-1000.00;-34.408;-70.064;23;3483.52;71.96;4;2.014
+M;0001;007;03;201;87.65;0.00;0.00;0.00;34.89;6.41;29.80;30.00;25.10;20.66;-9999.00;48.43;1199;;;;;;26.70;33.10;24.41;28.31;0.00;25.00;17.50;80.00;27.90;-1000.00;-21.400;-70.064;23;3484.62;71.96;4;2.014
+M;0001;008;03;203;77.41;0.00;0.00;0.00;32.94;6.50;29.80;30.00;25.10;20.66;-9999.00;48.44;1200;;;;;;26.70;33.10;24.47;28.31;0.00;25.00;17.50;80.00;27.92;-1000.00;-8.408;-70.064;23;3483.90;71.97;4;2.014
+M;0001;009;03;204;81.87;0.00;0.00;0.00;32.61;6.52;29.80;30.00;25.10;20.66;-9999.00;48.45;1200;;;;;;26.70;33.10;24.44;28.31;0.00;24.50;17.50;80.00;27.93;-1000.00;-8.408;-57.088;23;3483.66;71.97;4;2.014
+M;0001;010;03;206;85.25;0.00;0.00;0.00;33.99;6.45;29.80;30.00;25.10;20.66;-9999.00;48.53;1200;;;;;;26.70;33.10;24.44;28.31;0.00;24.50;17.50;80.00;27.96;-1000.00;-21.376;-57.088;23;3483.83;71.96;4;2.014
+M;0001;011;03;207;75.69;0.00;0.00;0.00;32.04;6.54;29.80;30.00;25.10;20.65;-9999.00;48.54;1200;;;;;;26.70;33.10;24.47;28.31;0.00;24.50;17.00;80.00;27.97;-1000.00;-34.376;-57.088;23;3483.78;71.97;4;2.014
+M;0001;012;03;208;78.77;0.00;0.00;0.00;32.86;6.50;29.80;30.00;25.10;20.65;-9999.00;48.55;1200;;;;;;26.80;33.20;24.38;28.31;0.00;24.50;17.00;80.00;27.99;-1000.00;-47.376;-57.088;23;3483.68;71.97;4;2.014
+M;0001;013;03;210;77.35;0.00;0.00;0.00;32.62;6.52;29.80;30.00;25.10;20.65;-9999.00;48.59;1200;;;;;;26.80;33.20;24.38;28.31;0.00;24.50;17.00;80.00;28.05;-1000.00;-60.376;-57.088;23;3483.71;71.97;4;2.014
+M;0001;014;03;211;77.36;0.00;0.00;0.00;32.77;6.51;29.80;30.00;25.10;20.64;-9999.00;48.59;1199;;;;;;26.80;33.20;24.38;28.38;0.00;24.00;16.50;80.00;28.05;-1000.00;-73.376;-57.088;23;3483.40;71.98;4;2.014
+M;0001;015;03;212;75.23;0.00;0.00;0.00;32.52;6.52;29.80;30.00;25.20;20.64;-9999.00;48.64;1199;;;;;;26.80;33.30;24.44;28.38;0.00;25.00;17.00;80.00;28.07;-1000.00;-86.368;-57.088;23;3483.35;71.98;4;2.014
+M;0001;016;03;214;78.66;0.00;0.00;0.00;34.17;6.44;29.80;30.00;25.20;20.64;-9999.00;48.67;1200;;;;;;26.80;33.20;24.34;28.38;0.00;25.00;17.00;80.00;28.10;-1000.00;-99.376;-57.088;23;3484.18;71.98;4;2.014
+M;0001;017;03;215;72.52;0.00;0.00;0.00;32.25;6.53;29.80;30.00;25.20;20.64;-9999.00;48.70;1200;;;;;;26.80;33.20;24.34;28.38;0.00;24.50;16.50;80.00;28.12;-1000.00;-99.376;-44.096;23;3484.35;71.98;4;2.014
+M;0001;018;03;216;83.84;0.00;0.00;0.00;33.68;6.46;29.80;30.00;25.20;20.64;-9999.00;48.73;1200;;;;;;26.80;33.30;24.44;28.38;0.00;25.00;16.50;80.00;28.13;-1000.00;-86.400;-44.096;23;3483.68;71.98;4;2.014
+M;0001;019;03;218;83.12;0.00;0.00;0.00;33.31;6.48;29.80;30.00;25.20;20.64;-9999.00;48.74;1199;;;;;;26.80;33.30;24.47;28.38;0.00;25.00;16.50;80.00;28.14;-1000.00;-73.408;-44.096;23;3483.69;71.98;4;2.014
+M;0001;020;03;219;85.17;0.00;0.00;0.00;33.90;6.45;29.80;30.00;25.20;20.64;-9999.00;48.75;1199;;;;;;26.80;33.30;24.47;28.38;0.00;25.00;16.50;80.00;28.17;-1000.00;-60.408;-44.096;23;3483.39;71.97;4;2.014
+M;0001;021;03;220;90.37;0.00;0.00;0.00;34.34;6.43;29.80;30.00;25.20;20.64;-9999.00;48.80;1199;;;;;;26.80;33.30;24.47;28.38;0.00;25.50;16.50;80.00;28.18;-1000.00;-47.400;-44.096;23;3483.27;71.98;4;2.014
+M;0001;022;03;222;86.76;0.00;0.00;0.00;33.95;6.45;29.80;30.00;25.20;20.63;-9999.00;48.84;1199;;;;;;26.80;33.30;24.41;28.38;0.00;25.50;16.50;80.00;28.19;-1000.00;-34.408;-44.096;23;3482.94;71.98;4;2.014
+M;0001;023;03;223;85.90;0.00;0.00;0.00;33.51;6.47;29.80;30.00;25.20;20.63;-9999.00;48.87;1199;;;;;;26.80;33.30;24.41;28.38;0.00;26.00;16.50;80.00;28.22;-1000.00;-21.408;-44.096;23;3482.02;71.99;4;2.014
+M;0001;024;03;224;92.16;0.00;0.00;0.00;34.55;6.42;29.80;30.00;25.20;20.63;-9999.00;48.90;1199;;;;;;26.80;33.30;24.41;28.38;0.00;26.00;16.50;80.00;28.23;-1000.00;-8.408;-44.096;23;3482.07;71.98;4;2.014
+M;0001;025;03;226;94.31;0.00;0.00;0.00;35.23;6.39;29.80;30.00;25.20;20.63;-9999.00;48.91;1199;;;;;;26.80;33.40;24.38;28.38;0.00;26.00;16.50;80.00;28.24;-1000.00;-8.408;-31.112;23;3482.81;71.98;4;2.014
+M;0001;026;03;227;83.33;0.00;0.00;0.00;33.46;6.48;29.70;30.00;25.20;20.62;-9999.00;48.98;1200;;;;;;26.80;33.40;24.38;28.38;0.00;27.00;16.50;80.00;28.25;-1000.00;-21.376;-31.112;23;3481.55;71.98;4;2.014
+M;0001;027;03;228;98.16;0.00;0.00;0.00;35.99;6.36;29.70;30.00;25.20;20.62;-9999.00;49.06;1200;;;;;;26.80;33.40;24.41;28.38;0.00;27.50;16.50;80.00;28.28;-1000.00;-34.376;-31.112;23;3482.45;71.99;4;2.014
+M;0001;028;03;230;82.30;0.00;0.00;0.00;33.64;6.47;29.70;30.00;25.20;20.62;-9999.00;49.06;1200;;;;;;26.80;33.40;24.44;28.38;0.00;27.50;16.50;80.00;28.28;-1000.00;-47.376;-31.112;23;3482.32;71.99;4;2.014
+M;0001;029;03;231;80.69;0.00;0.00;0.00;33.44;6.48;29.70;30.00;25.30;20.62;-9999.00;49.11;1200;;;;;;26.90;33.50;24.44;28.38;0.00;28.00;16.50;80.00;28.28;-1000.00;-60.376;-31.112;23;3482.85;71.99;4;2.014
+M;0001;030;03;232;78.88;0.00;0.00;0.00;32.80;6.51;29.70;30.00;25.30;20.62;-9999.00;49.20;1200;;;;;;26.90;33.50;24.47;28.38;0.00;29.00;16.50;80.00;28.29;-1000.00;-73.376;-31.112;23;3483.66;71.99;4;2.014
+M;0001;031;03;234;77.33;0.00;0.00;0.00;32.94;6.50;29.70;30.00;25.30;20.62;-9999.00;49.21;1200;;;;;;26.90;33.50;24.44;28.38;0.00;29.00;16.50;80.00;28.29;-1000.00;-86.360;-31.112;23;3483.39;72.00;4;2.014
+M;0001;032;03;235;70.86;0.00;0.00;0.00;32.03;6.55;29.70;30.00;25.30;20.61;-9999.00;49.28;1200;;;;;;26.90;33.50;24.44;28.38;0.00;30.00;16.50;80.00;28.29;-1000.00;-99.368;-31.112;23;3483.51;72.00;4;2.014
+P;0001;;;235;;;;;;;29.70;30.00;25.30;20.61;-9999.00;49.28;1200;;;;;;26.90;33.50;24.44;28.38;0.00;30.00;16.50;80.00;28.29;-1000.00;-99.368;-31.112;23;;;;2.015;1.335;1.079;1.048;1.319;
+P;0001;;;236;;;;;;;29.70;30.00;25.30;20.61;-9999.00;49.32;1200;;;;;;26.90;33.50;24.44;28.38;0.00;30.00;16.50;80.00;28.29;-1000.00;-99.368;-31.112;1;;;;2.015;1.335;1.079;1.048;1.317;
+M;0001;001;04;258;31.91;0.00;0.00;0.00;37.44;121.99;29.60;30.10;25.40;20.58;-9999.00;50.06;1199;;;;;;27.00;33.70;24.38;28.44;0.00;36.00;13.50;80.00;28.42;-1000.00;-100.408;-65.592;22;2257.32;5.64;3;2.015
+M;0001;002;04;260;32.49;0.00;0.00;0.00;37.73;120.37;29.60;30.10;25.40;20.58;-9999.00;50.09;1199;;;;;;27.00;33.70;24.41;28.44;0.00;36.50;13.50;80.00;28.42;-1000.00;-87.400;-65.592;22;2255.76;5.66;3;2.015
+M;0001;003;04;261;33.30;0.00;0.00;0.00;37.91;119.36;29.60;30.10;25.40;20.58;-9999.00;50.14;1199;;;;;;27.00;33.70;24.41;28.44;0.00;36.50;13.50;80.00;28.42;-1000.00;-74.408;-65.592;22;2255.28;5.61;3;2.015
+M;0001;004;04;262;34.74;0.00;0.00;0.00;38.00;118.97;29.50;30.10;25.40;20.58;-9999.00;50.20;1199;;;;;;27.00;33.70;24.47;28.44;0.00;37.00;13.00;80.00;28.43;-1000.00;-61.408;-65.592;22;2254.64;5.65;3;2.015
+M;0001;005;04;264;32.22;0.00;0.00;0.00;37.63;121.05;29.50;30.10;25.40;20.57;-9999.00;50.24;1199;;;;;;27.00;33.80;24.41;28.44;0.00;37.00;13.00;80.00;28.43;-1000.00;-48.400;-65.592;22;2254.67;5.59;3;2.015
+M;0001;006;04;265;33.78;0.00;0.00;0.00;37.93;119.35;29.50;30.10;25.40;20.57;-9999.00;50.27;1199;;;;;;27.00;33.80;24.41;28.50;0.00;37.50;12.50;80.00;28.43;-1000.00;-35.408;-65.592;22;2253.81;5.62;3;2.015
+M;0001;007;04;266;32.77;0.00;0.00;0.00;37.78;120.22;29.50;30.10;25.40;20.57;-9999.00;50.30;1199;;;;;;27.10;33.80;24.44;28.50;0.00;38.00;12.50;80.00;28.43;-1000.00;-22.400;-65.592;22;2253.96;5.70;3;2.015
+M;0001;008;04;268;33.51;0.00;0.00;0.00;37.75;120.37;29.50;30.10;25.40;20.57;-9999.00;50.34;1199;;;;;;27.10;33.80;24.44;28.50;0.00;38.00;12.50;80.00;28.46;-1000.00;-9.408;-65.592;22;2253.92;5.63;3;2.015
+M;0001;009;04;269;31.22;0.00;0.00;0.00;37.20;123.50;29.50;30.10;25.40;20.57;-9999.00;50.35;1200;;;;;;27.10;33.80;24.50;28.50;0.00;38.00;12.50;80.00;28.46;-1000.00;-9.408;-52.584;22;2253.78;5.67;3;2.015
+M;0001;010;04;270;33.16;0.00;0.00;0.00;37.58;121.33;29.50;30.10;25.40;20.56;-9999.00;50.40;1200;;;;;;27.10;33.80;24.38;28.50;0.00;38.50;12.00;80.00;28.46;-1000.00;-22.376;-52.584;22;2253.15;5.68;3;2.015
+M;0001;011;04;272;31.33;0.00;0.00;0.00;37.41;122.33;29.50;30.10;25.40;20.56;-9999.00;50.48;1200;;;;;;27.10;33.80;24.38;28.50;0.00;39.00;12.00;80.00;28.47;-1000.00;-35.384;-52.584;22;2252.36;5.70;3;2.015
+M;0001;012;04;273;31.67;0.00;0.00;0.00;37.18;123.61;29.50;30.10;25.40;20.56;-9999.00;50.50;1199;;;;;;27.10;33.80;24.38;28.50;0.00;39.00;12.00;80.00;28.48;-1000.00;-48.376;-52.584;22;2252.04;5.67;3;2.015
+M;0001;013;04;274;32.63;0.00;0.00;0.00;37.64;121.00;29.50;30.10;25.40;20.56;-9999.00;50.53;1199;;;;;;27.10;33.80;24.41;28.50;0.00;39.00;11.50;80.00;28.47;-1000.00;-61.376;-52.584;22;2251.40;5.67;3;2.015
+M;0001;014;04;276;34.35;0.00;0.00;0.00;37.63;121.03;29.50;30.10;25.40;20.56;-9999.00;50.54;1200;;;;;;27.10;33.80;24.44;28.50;0.00;39.00;11.50;80.00;28.49;-1000.00;-74.376;-52.584;22;2253.06;5.54;3;2.015
+M;0001;015;04;277;34.32;0.00;0.00;0.00;37.82;119.96;29.50;30.10;25.40;20.56;-9999.00;50.55;1199;;;;;;27.10;33.90;24.44;28.50;0.00;39.00;11.50;80.00;28.49;-1000.00;-87.368;-52.584;22;2252.92;5.64;3;2.015
+M;0001;016;04;278;35.59;0.00;0.00;0.00;37.99;119.03;29.50;30.10;25.40;20.56;-9999.00;50.56;1199;;;;;;27.10;33.90;24.44;28.50;0.00;39.50;11.50;80.00;28.50;-1000.00;-100.368;-52.584;22;2253.34;5.68;3;2.015
+M;0001;017;04;280;34.93;0.00;0.00;0.00;37.83;119.92;29.50;30.10;25.40;20.56;-9999.00;50.60;1199;;;;;;27.10;33.80;24.50;28.50;0.00;39.00;11.50;80.00;28.52;-1000.00;-100.368;-39.600;22;2252.67;5.68;3;2.015
+M;0001;018;04;281;35.05;0.00;0.00;0.00;37.53;121.63;29.50;30.10;25.40;20.56;-9999.00;50.60;1200;;;;;;27.10;33.90;24.50;28.50;0.00;39.00;11.50;80.00;28.52;-1000.00;-87.400;-39.600;22;2251.95;5.58;3;2.015
+M;0001;019;04;282;34.28;0.00;0.00;0.00;37.49;121.71;29.60;30.10;25.50;20.55;-9999.00;50.71;1200;;;;;;27.10;33.90;24.47;28.50;0.00;39.50;11.50;80.00;28.52;-1000.00;-74.408;-39.600;22;2251.62;5.59;3;2.015
+M;0001;020;04;284;33.13;0.00;0.00;0.00;37.19;123.45;29.60;30.10;25.50;20.56;-9999.00;50.75;1200;;;;;;27.10;34.00;24.47;28.50;0.00;39.00;11.50;80.00;28.52;-1000.00;-61.408;-39.600;22;2251.17;5.64;3;2.015
+M;0001;021;04;285;31.32;0.00;0.00;0.00;36.99;124.60;29.60;30.10;25.50;20.55;-9999.00;50.75;1200;;;;;;27.10;34.00;24.47;28.50;0.00;39.00;11.50;80.00;28.53;-1000.00;-48.400;-39.600;22;2250.52;5.64;3;2.015
+M;0001;022;04;286;30.24;0.00;0.00;0.00;36.69;126.39;29.60;30.10;25.50;20.55;-9999.00;50.75;1200;;;;;;27.20;34.00;24.47;28.50;0.00;39.00;11.50;80.00;28.53;-1000.00;-35.416;-39.600;22;2249.81;5.66;3;2.015
+M;0001;023;04;288;31.53;0.00;0.00;0.00;37.09;124.00;29.60;30.10;25.50;20.55;-9999.00;50.77;1200;;;;;;27.20;34.00;24.41;28.50;0.00;39.50;11.00;80.00;28.54;-1000.00;-22.400;-39.600;22;2249.87;5.65;3;2.015
+M;0001;024;04;289;31.40;0.00;0.00;0.00;36.87;125.31;29.60;30.10;25.50;20.55;-9999.00;50.80;1200;;;;;;27.20;34.00;24.41;28.50;0.00;39.50;11.00;80.00;28.55;-1000.00;-9.408;-39.600;22;2249.81;5.60;3;2.015
+M;0001;025;04;290;35.82;0.00;0.00;0.00;37.28;122.92;29.60;30.10;25.50;20.55;-9999.00;50.82;1200;;;;;;27.20;34.00;24.44;28.50;0.00;39.50;11.00;80.00;28.56;-1000.00;-9.408;-26.600;22;2250.21;5.64;3;2.015
+M;0001;026;04;291;34.99;0.00;0.00;0.00;37.44;122.00;29.60;30.10;25.50;20.55;-9999.00;50.83;1199;;;;;;27.20;34.00;24.44;28.50;0.00;39.50;11.00;80.00;28.56;-1000.00;-22.376;-26.600;22;2249.55;5.66;3;2.015
+M;0001;027;04;293;35.04;0.00;0.00;0.00;37.46;121.89;29.60;30.10;25.50;20.55;-9999.00;50.84;1200;;;;;;27.20;34.00;24.41;28.50;0.00;39.50;11.00;80.00;28.57;-1000.00;-35.384;-26.600;22;2249.38;5.69;3;2.015
+M;0001;028;04;294;36.38;0.00;0.00;0.00;37.55;121.40;29.60;30.10;25.50;20.55;-9999.00;50.83;1200;;;;;;27.20;34.00;24.47;28.50;0.00;39.50;11.00;80.00;28.58;-1000.00;-48.376;-26.600;22;2250.23;5.68;3;2.015
+M;0001;029;04;296;36.89;0.00;0.00;0.00;37.69;120.60;29.60;30.10;25.50;20.55;-9999.00;50.84;1199;;;;;;27.20;34.00;24.41;28.56;0.00;39.50;11.00;80.00;28.59;-1000.00;-61.376;-26.600;22;2250.37;5.62;3;2.015
+M;0001;030;04;297;36.79;0.00;0.00;0.00;37.70;120.51;29.60;30.10;25.50;20.55;-9999.00;50.85;1199;;;;;;27.20;34.00;24.41;28.56;0.00;39.50;11.00;80.00;28.59;-1000.00;-74.376;-26.600;22;2250.82;5.63;3;2.015
+M;0001;031;04;298;37.69;0.00;0.00;0.00;37.79;119.98;29.60;30.10;25.50;20.54;-9999.00;50.79;1199;;;;;;27.20;34.10;24.38;28.56;0.00;38.50;11.00;80.00;28.61;-1000.00;-87.368;-26.600;22;2250.82;5.65;3;2.015
+M;0001;032;04;300;36.46;0.00;0.00;0.00;37.68;120.61;29.60;30.10;25.50;20.54;-9999.00;50.78;1200;;;;;;27.20;34.10;24.38;28.56;0.00;38.00;11.00;80.00;28.61;-1000.00;-100.368;-26.600;22;2251.91;5.62;3;2.015
+P;0001;;;300;;;;;;;29.60;30.10;25.50;20.54;-9999.00;50.78;1200;;;;;;27.20;34.10;24.38;28.56;0.00;38.00;11.00;80.00;28.61;-1000.00;-100.368;-26.600;22;;;;2.014;1.335;1.079;1.053;1.311;
+P;0001;;;302;;;;;;;29.70;30.10;25.50;20.54;-9999.00;50.83;1199;;;;;;27.20;34.10;24.38;28.56;0.00;37.50;10.50;80.00;28.61;-1000.00;-100.368;-26.600;2;;;;2.015;1.336;1.079;1.053;1.311;
+R;0001;;05;316;-9999.00;0.00;;;;;29.80;30.10;25.60;20.53;-9999.00;50.74;1200;LED;;;;;27.30;34.20;24.41;28.56;0.00;34.00;10.00;80.00;28.71;-1000.00;-124.864;-69.560;12;8192.00;0.00;0;2.015
+M;0001;001;05;321;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.80;30.10;25.60;20.52;-9999.00;50.70;1200;;;;;;27.30;34.20;24.53;28.56;0.00;33.50;9.50;80.00;28.75;-1000.00;-103.408;-67.096;17;8192.00;0.00;0;2.015
+M;0001;002;05;325;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;30.10;25.60;20.51;-9999.00;50.70;1199;;;;;;27.40;34.30;24.44;28.62;0.00;31.00;9.50;80.00;28.78;-1000.00;-90.400;-67.096;17;8192.00;0.00;0;2.015
+M;0001;003;05;330;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;30.10;25.70;20.50;-9999.00;50.63;1199;;;;;;27.40;34.30;24.38;28.62;0.00;30.00;9.00;80.00;28.82;-1000.00;-77.408;-67.096;17;8192.00;0.00;0;2.015
+M;0001;004;05;334;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.10;25.70;20.49;-9999.00;50.63;1199;;;;;;27.40;34.30;24.41;28.62;0.00;28.50;8.50;80.00;28.83;-1000.00;-64.400;-67.096;17;8192.00;0.00;0;2.015
+M;0001;005;05;339;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.10;25.70;20.49;-9999.00;50.63;1199;;;;;;27.50;34.30;24.44;28.62;0.00;27.00;8.50;80.00;28.88;-1000.00;-51.400;-67.096;17;8192.00;0.00;0;2.015
+M;0001;006;05;343;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.10;25.70;20.48;-9999.00;50.55;1200;;;;;;27.50;34.40;24.50;28.62;0.00;26.50;8.00;80.00;28.92;-1000.00;-38.408;-67.096;17;8192.00;0.00;0;2.015
+M;0001;007;05;347;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.20;25.70;20.48;-9999.00;50.59;1199;;;;;;27.50;34.40;24.47;28.62;0.00;25.00;7.50;80.00;28.95;-1000.00;-25.400;-67.096;17;8192.00;0.00;0;2.015
+M;0001;008;05;352;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.20;25.70;20.48;-9999.00;50.62;1199;;;;;;27.50;34.50;24.47;28.69;0.00;24.00;6.50;80.00;28.98;-1000.00;-12.408;-67.096;17;8192.00;0.00;0;2.015
+M;0001;009;05;356;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.20;25.80;20.47;-9999.00;50.62;1200;;;;;;27.50;34.50;24.44;28.69;0.00;23.50;6.50;80.00;29.01;-1000.00;-12.408;-54.088;17;8192.00;0.00;0;2.015
+M;0001;010;05;361;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.20;25.80;20.46;-9999.00;50.60;1200;;;;;;27.60;34.50;24.47;28.69;0.00;23.00;6.00;80.00;29.04;-1000.00;-25.376;-54.088;17;8192.00;0.00;0;2.015
+M;0001;011;05;365;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.20;25.80;20.45;-9999.00;50.64;1199;;;;;;27.60;34.50;24.50;28.69;0.00;22.50;6.50;80.00;29.07;-1000.00;-38.384;-54.088;17;8192.00;0.00;0;2.015
+M;0001;012;05;369;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;25.80;20.45;-9999.00;50.68;1199;;;;;;27.60;34.60;24.44;28.69;0.00;22.50;6.50;80.00;29.08;-1000.00;-51.376;-54.088;17;8192.00;0.00;0;2.015
+M;0001;013;05;374;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;25.80;20.44;-9999.00;50.68;1198;;;;;;27.70;34.60;24.41;28.69;0.00;22.50;7.00;80.00;29.11;-1000.00;-64.376;-54.088;17;8192.00;0.00;0;2.015
+M;0001;014;05;378;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;25.90;20.44;-9999.00;50.73;1199;;;;;;27.70;34.60;24.53;28.69;0.00;21.50;6.50;80.00;29.14;-1000.00;-77.376;-54.088;17;8192.00;0.00;0;2.015
+M;0001;015;05;383;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;25.90;20.44;-9999.00;50.73;1202;;;;;;27.70;34.60;24.38;28.69;0.00;21.50;6.50;80.00;29.14;-1000.00;-90.360;-54.088;17;8192.00;0.00;0;2.015
+M;0001;016;05;387;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;25.90;20.44;-9999.00;50.79;1200;;;;;;27.70;34.70;24.47;28.69;0.00;21.50;6.50;80.00;29.17;-1000.00;-103.368;-54.088;17;8192.00;0.00;0;2.015
+M;0001;017;05;392;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;25.90;20.43;-9999.00;50.81;1200;;;;;;27.80;34.70;24.44;28.75;0.00;21.50;6.50;80.00;29.18;-1000.00;-103.376;-41.096;17;8192.00;0.00;0;2.015
+M;0001;018;05;396;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;25.90;20.43;-9999.00;50.85;1199;;;;;;27.80;34.70;24.47;28.75;0.00;21.00;6.00;80.00;29.20;-1000.00;-90.408;-41.096;17;8192.00;0.00;0;2.015
+M;0001;019;05;401;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;25.90;20.42;-9999.00;50.93;1200;;;;;;27.80;34.80;24.44;28.75;0.00;21.50;6.00;80.00;29.22;-1000.00;-77.408;-41.096;17;8192.00;0.00;0;2.015
+M;0001;020;05;405;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;25.90;20.42;-9999.00;51.00;1199;;;;;;27.90;34.80;24.47;28.75;0.00;21.00;6.50;80.00;29.24;-1000.00;-64.408;-41.096;17;8192.00;0.00;0;2.015
+M;0001;021;05;410;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;25.90;20.42;-9999.00;51.12;1200;;;;;;27.90;34.80;24.44;28.75;0.00;21.00;6.50;80.00;29.25;-1000.00;-51.400;-41.096;17;8192.00;0.00;0;2.015
+M;0001;022;05;414;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.00;20.42;-9999.00;51.12;1200;;;;;;27.90;34.80;24.44;28.75;0.00;21.00;6.00;80.00;29.25;-1000.00;-38.408;-41.096;17;8192.00;0.00;0;2.015
+M;0001;023;05;419;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.00;20.42;-9999.00;51.16;1201;;;;;;28.00;34.80;24.44;28.81;0.00;21.00;6.00;80.00;29.27;-1000.00;-25.400;-41.096;17;8192.00;0.00;0;2.015
+M;0001;024;05;423;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.00;20.42;-9999.00;51.23;1199;;;;;;28.00;34.90;24.47;28.81;0.00;21.00;6.00;80.00;29.29;-1000.00;-12.408;-41.096;17;8192.00;0.00;0;2.015
+M;0001;025;05;428;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.00;20.41;-9999.00;51.26;1198;;;;;;28.00;34.90;24.44;28.81;0.00;21.00;5.50;80.00;29.29;-1000.00;-12.408;-28.104;17;8192.00;0.00;0;2.015
+M;0001;026;05;432;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.00;20.41;-9999.00;51.28;1200;;;;;;28.00;35.00;24.47;28.81;0.00;21.00;5.50;80.00;29.32;-1000.00;-25.376;-28.104;17;8192.00;0.00;0;2.015
+M;0001;027;05;436;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.10;20.40;-9999.00;51.39;1199;;;;;;28.10;35.00;24.47;28.81;0.00;21.00;5.50;80.00;29.32;-1000.00;-38.384;-28.104;17;8192.00;0.00;0;2.015
+M;0001;028;05;441;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.10;20.40;-9999.00;51.41;1199;;;;;;28.10;35.00;24.44;28.81;0.00;21.00;5.00;80.00;29.32;-1000.00;-51.376;-28.104;17;8192.00;0.00;0;2.015
+M;0001;029;05;445;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.10;20.39;-9999.00;51.46;1200;;;;;;28.10;35.00;24.47;28.81;0.00;21.00;5.50;80.00;29.34;-1000.00;-64.376;-28.104;17;8192.00;0.00;0;2.015
+M;0001;030;05;450;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.10;20.39;-9999.00;51.53;1199;;;;;;28.20;35.00;24.53;28.81;0.00;21.00;5.00;80.00;29.36;-1000.00;-77.368;-28.104;17;8192.00;0.00;0;2.015
+M;0001;031;05;454;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.10;20.38;-9999.00;51.57;1199;;;;;;28.20;35.00;24.47;28.88;0.00;21.00;5.50;80.00;29.36;-1000.00;-90.360;-28.104;17;8192.00;0.00;0;2.015
+M;0001;032;05;459;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.10;26.10;20.38;-9999.00;51.63;1200;;;;;;28.20;35.10;24.47;28.81;0.00;20.50;5.00;80.00;29.38;-1000.00;-103.368;-28.104;17;8192.00;0.00;0;2.015
+P;0001;;;459;;;;;;;30.00;30.10;26.10;20.38;-9999.00;51.63;1200;#;;;;;28.20;35.10;24.47;28.81;0.00;20.50;5.00;80.00;29.38;-1000.00;-103.368;-28.104;17;;;;2.014;1.335;1.081;1.062;1.321;
+P;0001;;;459;;;;;;;30.00;30.10;26.10;20.38;-9999.00;51.63;1200;;;;;;28.20;35.10;24.47;28.88;0.00;20.50;5.00;80.00;29.38;-1000.00;-103.368;-28.104;0;;;;2.014;1.335;1.081;1.062;1.321;
+R;0001;;06;474;-9999.00;0.00;;;;;30.00;30.10;26.20;20.36;-9999.00;51.82;1200;LED;;;;;28.30;35.10;24.44;28.88;0.00;20.50;5.00;80.00;29.39;-1000.00;-124.864;-69.552;11;8192.00;0.00;0;2.014
+M;0001;001;06;479;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.10;26.20;20.35;-9999.00;51.88;1200;;;;;;28.40;35.20;24.50;28.88;0.00;20.00;4.00;80.00;29.41;-1000.00;-103.408;-67.088;16;8192.00;0.00;0;2.014
+M;0001;002;06;483;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.20;20.35;-9999.00;51.96;1199;;;;;;28.40;35.20;24.47;28.88;0.00;20.00;3.50;80.00;29.41;-1000.00;-90.400;-67.088;16;8192.00;0.00;0;2.014
+M;0001;003;06;488;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.20;20.34;-9999.00;51.99;1199;;;;;;28.40;35.20;24.50;28.94;0.00;19.50;3.00;80.00;29.43;-1000.00;-77.408;-67.088;16;8192.00;0.00;0;2.014
+M;0001;004;06;492;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.30;20.34;-9999.00;52.00;1200;;;;;;28.50;35.30;24.44;28.88;0.00;19.00;2.50;80.00;29.43;-1000.00;-64.408;-67.088;16;8192.00;0.00;0;2.014
+M;0001;005;06;497;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.30;20.34;-9999.00;52.03;1200;;;;;;28.50;35.30;24.47;28.94;0.00;19.00;2.50;80.00;29.45;-1000.00;-51.400;-67.088;16;8192.00;0.00;0;2.014
+M;0001;006;06;501;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.30;20.34;-9999.00;52.12;1199;;;;;;28.50;35.30;24.47;28.94;0.00;19.50;2.50;80.00;29.46;-1000.00;-38.408;-67.088;16;8192.00;0.00;0;2.014
+M;0001;007;06;506;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.30;20.34;-9999.00;52.10;1199;;;;;;28.60;35.30;24.47;28.94;0.00;19.00;2.50;80.00;29.48;-1000.00;-25.400;-67.088;16;8192.00;0.00;0;2.014
+M;0001;008;06;510;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.30;20.34;-9999.00;52.18;1199;;;;;;28.60;35.30;24.44;28.94;0.00;18.50;2.00;80.00;29.48;-1000.00;-12.408;-67.088;16;8192.00;0.00;0;2.014
+M;0001;009;06;514;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.30;20.33;-9999.00;52.20;1200;;;;;;28.60;35.30;24.38;28.94;0.00;18.50;2.00;80.00;29.49;-1000.00;-12.408;-54.088;16;8192.00;0.00;0;2.014
+M;0001;010;06;519;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.30;20.33;-9999.00;52.27;1199;;;;;;28.70;35.30;24.38;28.94;0.00;18.00;2.00;80.00;29.50;-1000.00;-25.376;-54.088;16;8192.00;0.00;0;2.014
+M;0001;011;06;523;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.40;20.33;-9999.00;52.27;1200;;;;;;28.70;35.40;24.47;29.00;0.00;18.00;1.50;80.00;29.51;-1000.00;-38.384;-54.088;16;8192.00;0.00;0;2.014
+M;0001;012;06;528;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.40;20.32;-9999.00;52.29;1200;;;;;;28.70;35.40;24.50;29.00;0.00;18.00;1.50;80.00;29.52;-1000.00;-51.376;-54.088;16;8192.00;0.00;0;2.014
+M;0001;013;06;532;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.40;20.32;-9999.00;52.29;1199;;;;;;28.80;35.40;24.50;29.00;0.00;17.50;1.50;80.00;29.53;-1000.00;-64.376;-54.088;16;8192.00;0.00;0;2.014
+M;0001;014;06;537;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.40;20.32;-9999.00;52.36;1199;;;;;;28.80;35.50;24.47;29.00;0.00;17.50;2.00;80.00;29.54;-1000.00;-77.368;-54.088;16;8192.00;0.00;0;2.014
+M;0001;015;06;541;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.40;20.32;-9999.00;52.31;1200;;;;;;28.80;35.50;24.50;29.00;0.00;17.00;1.50;80.00;29.54;-1000.00;-90.368;-54.088;16;8192.00;0.00;0;2.014
+M;0001;016;06;546;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.10;26.40;20.31;-9999.00;52.41;1200;;;;;;28.90;35.50;24.44;29.00;0.00;17.00;2.50;80.00;29.56;-1000.00;-103.368;-54.088;16;8192.00;0.00;0;2.014
+M;0001;017;06;550;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.40;20.31;-9999.00;52.45;1200;;;;;;28.90;35.50;24.34;29.00;0.00;17.00;3.00;80.00;29.57;-1000.00;-103.376;-41.096;16;8192.00;0.00;0;2.014
+M;0001;018;06;554;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.50;20.31;-9999.00;52.51;1199;;;;;;28.90;35.50;24.50;29.00;0.00;16.50;3.50;80.00;29.58;-1000.00;-90.400;-41.096;16;8192.00;0.00;0;2.014
+M;0001;019;06;559;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.50;20.31;-9999.00;52.56;1200;;;;;;29.00;35.50;24.41;29.00;0.00;16.50;3.50;80.00;29.59;-1000.00;-77.408;-41.096;16;8192.00;0.00;0;2.014
+M;0001;020;06;563;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.50;20.31;-9999.00;52.51;1199;;;;;;29.00;35.50;24.44;29.00;0.00;16.50;3.50;80.00;29.61;-1000.00;-64.408;-41.096;16;8192.00;0.00;0;2.014
+M;0001;021;06;568;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.50;20.31;-9999.00;52.61;1199;;;;;;29.00;35.50;24.41;29.00;0.00;16.00;3.50;80.00;29.61;-1000.00;-51.400;-41.096;16;8192.00;0.00;0;2.014
+M;0001;022;06;572;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.50;20.30;-9999.00;52.61;1199;;;;;;29.10;35.60;24.47;29.06;0.00;16.00;3.50;80.00;29.62;-1000.00;-38.408;-41.096;16;8192.00;0.00;0;2.014
+M;0001;023;06;577;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.50;20.30;-9999.00;52.65;1199;;;;;;29.10;35.60;24.53;29.06;0.00;16.00;3.50;80.00;29.63;-1000.00;-25.400;-41.096;16;8192.00;0.00;0;2.014
+M;0001;024;06;581;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.50;20.30;-9999.00;52.73;1200;;;;;;29.10;35.60;24.41;29.06;0.00;15.50;3.50;80.00;29.63;-1000.00;-12.408;-41.096;16;8192.00;0.00;0;2.014
+M;0001;025;06;585;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.60;20.30;-9999.00;52.78;1201;;;;;;29.20;35.60;24.44;29.06;0.00;15.50;3.00;80.00;29.64;-1000.00;-12.408;-28.104;16;8192.00;0.00;0;2.014
+M;0001;026;06;590;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.60;20.30;-9999.00;52.79;1200;;;;;;29.20;35.60;24.47;29.06;0.00;15.50;3.00;80.00;29.65;-1000.00;-25.376;-28.104;16;8192.00;0.00;0;2.014
+M;0001;027;06;594;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.60;20.29;-9999.00;52.82;1199;;;;;;29.30;35.60;24.50;29.06;0.00;15.00;3.00;80.00;29.66;-1000.00;-38.384;-28.104;16;8192.00;0.00;0;2.014
+M;0001;028;06;599;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.60;20.29;-9999.00;52.88;1199;;;;;;29.30;35.70;24.47;29.06;0.00;15.00;3.00;80.00;29.68;-1000.00;-51.376;-28.104;16;8192.00;0.00;0;2.014
+M;0001;029;06;603;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.60;20.29;-9999.00;52.98;1200;;;;;;29.30;35.70;24.47;29.12;0.00;15.00;3.00;80.00;29.68;-1000.00;-64.376;-28.104;16;8192.00;0.00;0;2.014
+M;0001;030;06;607;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.60;20.28;-9999.00;53.02;1200;;;;;;29.40;35.70;24.50;29.06;0.00;15.00;2.50;80.00;29.68;-1000.00;-77.376;-28.104;16;8192.00;0.00;0;2.014
+M;0001;031;06;612;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.60;20.28;-9999.00;52.99;1199;;;;;;29.40;35.70;24.50;29.06;0.00;15.00;2.50;80.00;29.68;-1000.00;-90.368;-28.104;16;8192.00;0.00;0;2.014
+M;0001;032;06;617;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.10;30.00;26.70;20.27;-9999.00;53.03;1200;;;;;;29.40;35.80;24.47;29.12;0.00;14.50;2.50;80.00;29.70;-1000.00;-103.368;-28.104;16;8192.00;0.00;0;2.014
+P;0001;;;617;;;;;;;30.10;30.00;26.70;20.27;-9999.00;53.03;1200;#;;;;;29.40;35.80;24.47;29.12;0.00;14.50;2.50;80.00;29.70;-1000.00;-103.368;-28.104;16;;;;2.014;1.335;1.080;1.063;1.305;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 0 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 0 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 0 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 1 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 1 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 1 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 2 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 2 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 2 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 3 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 3 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 3 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 4 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 4 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 4 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 5 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 5 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 5 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 6 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 6 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 6 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 7 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 7 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;pH restart of module 1 and block 7 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 0 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 0 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 0 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 1 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 1 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 1 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 2 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 2 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 2 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 3 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 3 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 3 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 4 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 4 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 4 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 5 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 5 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 5 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 6 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 6 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 6 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 7 -- ucEnableWell  = 15;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 7 -- ucKeepLastCmd_Well  = 0;;;;
+C;0001;;;622;;;;;;;;;;;;;;;ph start of module 0 and block 7 -- ucResetTimeFeeding_Well  = 0;;;;
+F;0001;001;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;016;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;017;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;032;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;002;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;015;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;018;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;031;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;003;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;014;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;019;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;030;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;004;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;013;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;020;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;029;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;005;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;012;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;021;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;028;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;006;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;011;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;022;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;027;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;007;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;010;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;023;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;026;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;008;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;009;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;024;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;025;;625;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0001;001;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;016;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;017;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;032;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;002;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;015;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;018;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;031;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;003;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;014;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;019;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;030;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;004;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;013;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;020;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;029;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;005;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;012;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;021;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;028;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;006;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;011;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;022;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;027;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;007;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;010;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;023;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;026;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;008;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;009;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;024;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;025;;625;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0001;001;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;016;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;017;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;032;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;002;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;015;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;018;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;031;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;003;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;014;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;019;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;030;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;004;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;013;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;020;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;029;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;005;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;012;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;021;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;028;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;006;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;011;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;022;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;027;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;007;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;010;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;023;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;026;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;008;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;009;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;024;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0001;025;;625;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+P;0002;;;625;;;;;;;30.10;30.00;26.70;20.27;-9999.00;53.13;1200;;;;;;29.50;35.80;24.47;29.12;0.00;14.50;2.50;80.00;29.71;-1000.00;-124.864;-69.560;16;;;;2.014;1.334;1.080;1.063;1.305;
+P;0002;;;626;;;;;;;30.10;30.00;26.70;20.27;-9999.00;53.15;1200;;;;;;29.50;35.80;24.47;29.12;0.00;14.50;2.50;80.00;29.71;-1000.00;-124.864;-69.560;1;;;;2.015;1.336;1.080;1.064;1.305;
+R;0002;;01;656;215.40;0.00;;;;;30.10;30.00;26.80;20.25;-9999.00;53.51;1199;2852.74;;;;;29.80;35.90;24.38;29.19;0.00;13.50;2.00;80.00;29.75;-1000.00;-124.864;-69.560;30;2852.74;72.69;2;2.015
+M;0002;001;01;658;9.56;0.00;9.04;0.00;-2.53;0.00;30.10;30.00;26.80;20.25;-9999.00;53.55;1200;#;;;;;29.80;35.90;24.41;29.19;0.00;13.50;2.00;80.00;29.75;-1000.00;-103.408;-67.096;32;2850.39;72.67;2;2.015
+M;0002;002;01;659;9.36;0.00;8.84;0.00;-2.72;0.00;30.10;30.00;26.80;20.24;-9999.00;53.52;1200;;;;;;29.80;35.90;24.41;29.19;0.00;14.00;2.50;80.00;29.75;-1000.00;-90.400;-67.096;32;2849.38;72.67;2;2.015
+M;0002;003;01;660;9.53;0.00;9.00;0.00;-2.57;0.00;30.10;30.00;26.80;20.24;-9999.00;53.58;1200;;;;;;29.80;35.90;24.47;29.19;0.00;13.50;2.00;80.00;29.75;-1000.00;-77.408;-67.096;32;2847.84;72.67;2;2.015
+M;0002;004;01;662;9.42;0.00;8.90;0.00;-2.58;0.00;30.10;30.00;26.80;20.24;-9999.00;53.58;1199;;;;;;29.80;35.90;24.47;29.19;0.00;13.50;2.00;80.00;29.75;-1000.00;-64.408;-67.096;32;2847.47;72.68;2;2.015
+M;0002;005;01;663;9.53;0.00;9.01;0.00;-2.68;0.00;30.10;30.00;26.80;20.24;-9999.00;53.60;1200;;;;;;29.80;35.90;24.47;29.19;0.00;13.50;2.00;80.00;29.75;-1000.00;-51.400;-67.096;32;2847.79;72.67;2;2.015
+M;0002;006;01;664;9.52;0.00;8.99;0.00;-2.59;0.00;30.10;30.00;26.80;20.24;-9999.00;53.62;1200;;;;;;29.80;35.90;24.47;29.19;0.00;13.50;2.00;80.00;29.76;-1000.00;-38.408;-67.096;32;2846.05;72.67;2;2.015
+M;0002;007;01;666;9.46;0.00;8.94;0.00;-2.63;0.00;30.10;30.00;26.80;20.24;-9999.00;53.66;1200;;;;;;29.90;36.00;24.50;29.19;0.00;13.50;1.50;80.00;29.76;-1000.00;-25.400;-67.096;32;2845.52;72.67;2;2.015
+M;0002;008;01;667;11.32;0.00;10.70;0.00;-2.76;0.00;30.10;30.00;26.80;20.24;-9999.00;53.71;1200;;;;;;29.90;35.90;24.50;29.19;0.00;13.50;1.50;80.00;29.77;-1000.00;-12.408;-67.096;32;2845.30;72.67;2;2.015
+M;0002;009;01;668;9.80;0.00;9.26;0.00;-2.72;0.00;30.10;30.00;26.80;20.24;-9999.00;53.73;1200;;;;;;29.90;35.90;24.47;29.19;0.00;13.00;1.50;80.00;29.77;-1000.00;-12.408;-54.088;32;2846.00;72.67;2;2.015
+M;0002;010;01;670;10.47;0.00;9.90;0.00;-2.76;0.00;30.10;30.00;26.90;20.24;-9999.00;53.74;1200;;;;;;29.90;35.90;24.44;29.19;0.00;13.50;1.50;80.00;29.76;-1000.00;-25.376;-54.088;32;2844.75;72.67;2;2.015
+M;0002;011;01;671;9.91;0.00;9.37;0.00;-2.68;0.00;30.10;30.00;26.90;20.24;-9999.00;53.77;1199;;;;;;29.90;36.00;24.44;29.19;0.00;13.50;1.50;80.00;29.77;-1000.00;-38.384;-54.088;32;2843.78;72.67;2;2.015
+M;0002;012;01;673;10.43;0.00;9.86;0.00;-2.68;0.00;30.10;30.00;26.90;20.24;-9999.00;53.77;1199;;;;;;29.90;36.00;24.44;29.19;0.00;13.00;1.50;80.00;29.77;-1000.00;-51.376;-54.088;32;2843.86;72.67;2;2.015
+M;0002;013;01;674;10.70;0.00;10.11;0.00;-2.77;0.00;30.10;30.00;26.90;20.24;-9999.00;53.77;1199;;;;;;29.90;36.00;24.47;29.19;0.00;13.50;1.50;80.00;29.78;-1000.00;-64.376;-54.088;32;2842.87;72.67;2;2.015
+M;0002;014;01;675;9.89;0.00;9.35;0.00;-2.93;0.00;30.10;30.00;26.90;20.24;-9999.00;53.78;1200;;;;;;29.90;36.00;24.47;29.19;0.00;13.50;1.50;80.00;29.78;-1000.00;-77.368;-54.088;32;2843.74;72.67;2;2.015
+M;0002;015;01;677;9.94;0.00;9.39;0.00;-2.63;0.00;30.10;30.00;26.90;20.24;-9999.00;53.77;1199;;;;;;29.90;36.00;24.47;29.19;0.00;13.50;1.50;80.00;29.77;-1000.00;-90.368;-54.088;32;2844.85;72.67;2;2.015
+M;0002;016;01;678;10.00;0.00;9.45;0.00;-2.73;0.00;30.10;30.10;26.90;20.24;-9999.00;53.78;1199;;;;;;30.00;36.00;24.50;29.19;0.00;13.50;1.00;80.00;29.78;-1000.00;-103.368;-54.088;32;2845.46;72.68;2;2.015
+M;0002;017;01;679;10.81;0.00;10.22;0.00;-2.76;0.00;30.10;30.00;26.90;20.24;-9999.00;53.77;1199;;;;;;30.00;36.00;24.50;29.19;0.00;13.50;0.50;80.00;29.78;-1000.00;-103.376;-41.096;32;2844.80;72.67;2;2.015
+M;0002;018;01;680;10.21;0.00;9.65;0.00;-2.75;0.00;30.10;30.00;26.90;20.24;-9999.00;53.77;1200;;;;;;30.00;36.00;24.47;29.19;0.00;13.50;0.50;80.00;29.78;-1000.00;-90.400;-41.096;32;2842.72;72.68;2;2.015
+M;0002;019;01;682;10.24;0.00;9.68;0.00;-2.80;0.00;30.10;30.00;26.90;20.23;-9999.00;53.80;1200;;;;;;30.00;36.00;24.56;29.19;0.00;13.50;1.00;80.00;29.78;-1000.00;-77.408;-41.096;32;2841.72;72.67;2;2.015
+M;0002;020;01;683;9.99;0.00;9.44;0.00;-2.56;0.00;30.10;30.00;26.90;20.23;-9999.00;53.82;1200;;;;;;30.00;36.00;24.56;29.19;0.00;13.50;1.00;80.00;29.77;-1000.00;-64.408;-41.096;32;2841.12;72.68;2;2.015
+M;0002;021;01;684;10.25;0.00;9.69;0.00;-2.73;0.00;30.10;30.00;26.90;20.24;-9999.00;53.85;1199;;;;;;30.00;36.00;24.47;29.19;0.00;13.50;1.00;80.00;29.78;-1000.00;-51.400;-41.096;32;2840.25;72.68;2;2.015
+M;0002;022;01;686;9.86;0.00;9.32;0.00;-2.68;0.00;30.10;30.00;26.90;20.24;-9999.00;53.85;1199;;;;;;30.00;36.00;24.53;29.19;0.00;13.00;1.00;80.00;29.77;-1000.00;-38.408;-41.096;32;2838.84;72.68;2;2.015
+M;0002;023;01;687;10.60;0.00;10.02;0.00;-2.68;0.00;30.10;30.00;26.90;20.23;-9999.00;53.89;1199;;;;;;30.00;36.00;24.53;29.19;0.00;13.00;1.00;80.00;29.78;-1000.00;-25.400;-41.096;32;2838.22;72.68;2;2.015
+M;0002;024;01;688;10.08;0.00;9.53;0.00;-2.75;0.00;30.10;30.00;26.90;20.23;-9999.00;53.91;1199;;;;;;30.00;36.00;24.53;29.25;0.00;13.00;1.00;80.00;29.78;-1000.00;-12.408;-41.096;32;2838.82;72.68;2;2.015
+M;0002;025;01;690;10.82;0.00;10.22;0.00;-2.88;0.00;30.10;30.00;26.90;20.23;-9999.00;53.92;1199;;;;;;30.10;36.00;24.50;29.25;0.00;13.00;1.00;80.00;29.78;-1000.00;-12.408;-28.112;32;2840.40;72.68;2;2.015
+M;0002;026;01;691;10.78;0.00;10.19;0.00;-2.82;0.00;30.10;30.00;26.90;20.23;-9999.00;53.94;1200;;;;;;30.10;36.00;24.50;29.25;0.00;13.00;1.00;80.00;29.78;-1000.00;-25.376;-28.104;32;2838.27;72.68;2;2.015
+M;0002;027;01;692;9.83;0.00;9.29;0.00;-2.76;0.00;30.10;30.00;26.90;20.23;-9999.00;53.96;1200;;;;;;30.10;36.00;24.50;29.25;0.00;13.00;1.00;80.00;29.79;-1000.00;-38.384;-28.104;32;2838.66;72.68;2;2.015
+M;0002;028;01;694;10.35;0.00;9.78;0.00;-2.69;0.00;30.10;30.00;26.90;20.23;-9999.00;53.95;1200;;;;;;30.10;36.00;24.47;29.25;0.00;13.00;1.00;80.00;29.79;-1000.00;-51.376;-28.104;32;2838.56;72.68;2;2.015
+M;0002;029;01;695;10.62;0.00;10.04;0.00;-2.77;0.00;30.10;30.00;26.90;20.23;-9999.00;53.93;1199;;;;;;30.10;36.00;24.47;29.25;0.00;13.00;1.00;80.00;29.79;-1000.00;-64.376;-28.104;32;2838.80;72.68;2;2.015
+M;0002;030;01;696;10.77;0.00;10.18;0.00;-2.88;0.00;30.10;30.00;26.90;20.23;-9999.00;53.97;1199;;;;;;30.10;36.00;24.50;29.25;0.00;13.00;1.00;80.00;29.79;-1000.00;-77.376;-28.104;32;2839.54;72.68;2;2.015
+M;0002;031;01;698;9.98;0.00;9.43;0.00;-2.73;0.00;30.10;30.00;27.00;20.23;-9999.00;53.97;1200;;;;;;30.10;36.00;24.47;29.25;0.00;13.00;1.00;80.00;29.79;-1000.00;-90.360;-28.104;32;2840.67;72.68;2;2.015
+M;0002;032;01;699;10.32;0.00;9.75;0.00;-2.67;0.00;30.10;30.00;27.00;20.23;-9999.00;54.01;1200;;;;;;30.10;36.00;24.47;29.25;0.00;13.00;1.00;80.00;29.79;-1000.00;-103.368;-28.104;32;2840.27;72.69;2;2.015
+P;0002;;;699;;;;;;;30.10;30.00;27.00;20.23;-9999.00;54.01;1200;;;;;;30.10;36.00;24.47;29.25;0.00;13.00;1.00;80.00;29.79;-1000.00;-103.368;-28.104;32;;;;2.013;1.335;1.081;1.066;1.321;
+P;0002;;;699;;;;;;;30.10;30.00;27.00;20.23;-9999.00;54.01;1200;;;;;;30.10;36.00;24.47;29.25;0.00;13.00;1.00;80.00;29.79;-1000.00;-103.368;-28.104;0;;;;2.013;1.335;1.081;1.066;1.321;
+R;0002;;02;731;214.85;0.00;;;;;30.00;30.00;27.10;20.22;-9999.00;54.36;1200;2849.68;;;;;30.40;36.10;24.44;29.25;0.00;13.00;1.00;80.00;29.82;-1000.00;-124.864;-69.552;31;2849.68;72.70;2;2.013
+M;0002;001;02;733;38.39;0.00;36.37;0.00;-2.79;0.00;30.00;30.00;27.10;20.22;-9999.00;54.39;1200;#;;;;;30.40;36.10;24.47;29.31;0.00;13.00;1.00;80.00;29.82;-1000.00;-103.408;-67.088;33;2840.37;72.70;2;2.013
+M;0002;002;02;734;37.38;0.00;35.42;0.00;-2.81;0.00;30.00;30.00;27.10;20.22;-9999.00;54.39;1200;;;;;;30.40;36.10;24.50;29.31;0.00;13.00;1.00;80.00;29.82;-1000.00;-90.408;-67.088;33;2839.33;72.70;2;2.013
+M;0002;003;02;736;38.02;0.00;36.03;0.00;-2.79;0.00;30.10;30.00;27.10;20.22;-9999.00;54.40;1200;;;;;;30.50;36.10;24.56;29.31;0.00;13.00;1.00;80.00;29.82;-1000.00;-77.408;-67.088;33;2837.82;72.70;2;2.013
+M;0002;004;02;737;37.71;0.00;35.73;0.00;-2.79;0.00;30.00;30.00;27.10;20.21;-9999.00;54.43;1200;;;;;;30.50;36.10;24.56;29.31;0.00;12.50;1.00;80.00;29.82;-1000.00;-64.408;-67.088;33;2837.28;72.71;2;2.013
+M;0002;005;02;738;38.32;0.00;36.31;0.00;-2.82;0.00;30.00;30.00;27.10;20.21;-9999.00;54.46;1199;;;;;;30.50;36.10;24.50;29.31;0.00;12.50;1.00;80.00;29.82;-1000.00;-51.400;-67.088;33;2837.84;72.70;2;2.013
+M;0002;006;02;740;38.38;0.00;36.37;0.00;-2.81;0.00;30.10;30.00;27.10;20.21;-9999.00;54.47;1199;;;;;;30.50;36.10;24.50;29.31;0.00;12.50;0.50;80.00;29.82;-1000.00;-38.408;-67.088;33;2836.46;72.70;2;2.013
+M;0002;007;02;741;38.02;0.00;36.03;0.00;-2.83;0.00;30.10;30.00;27.10;20.21;-9999.00;54.49;1199;;;;;;30.50;36.10;24.50;29.31;0.00;12.00;0.50;80.00;29.82;-1000.00;-25.400;-67.088;33;2836.51;72.70;2;2.013
+M;0002;008;02;742;45.77;0.00;43.37;0.00;-2.83;0.00;30.10;30.00;27.10;20.21;-9999.00;54.48;1199;;;;;;30.50;36.10;24.53;29.31;0.00;12.00;0.50;80.00;29.82;-1000.00;-12.408;-67.088;33;2836.77;72.70;2;2.013
+M;0002;009;02;744;39.18;0.00;37.12;0.00;-2.81;0.00;30.00;30.00;27.10;20.21;-9999.00;54.49;1199;;;;;;30.50;36.10;24.50;29.31;0.00;12.00;0.50;80.00;29.83;-1000.00;-12.408;-54.088;33;2837.14;72.71;2;2.013
+M;0002;010;02;745;41.75;0.00;39.56;0.00;-2.84;0.00;30.00;30.00;27.10;20.21;-9999.00;54.52;1199;;;;;;30.50;36.10;24.50;29.31;0.00;12.50;0.50;80.00;29.83;-1000.00;-25.376;-54.088;33;2836.14;72.70;2;2.013
+M;0002;011;02;746;39.52;0.00;37.45;0.00;-2.80;0.00;30.00;30.00;27.10;20.21;-9999.00;54.57;1200;;;;;;30.50;36.10;24.47;29.31;0.00;12.50;0.50;80.00;29.83;-1000.00;-38.384;-54.088;33;2835.17;72.71;2;2.013
+M;0002;012;02;748;41.70;0.00;39.51;0.00;-2.81;0.00;30.00;30.00;27.10;20.21;-9999.00;54.58;1200;;;;;;30.60;36.10;24.56;29.31;0.00;12.50;0.50;80.00;29.83;-1000.00;-51.376;-54.088;33;2835.12;72.71;2;2.013
+M;0002;013;02;749;42.60;0.00;40.37;0.00;-2.78;0.00;30.10;30.00;27.10;20.21;-9999.00;54.56;1199;;;;;;30.60;36.10;24.56;29.31;0.00;12.00;0.00;80.00;29.83;-1000.00;-64.376;-54.088;33;2834.60;72.70;2;2.013
+M;0002;014;02;750;39.70;0.00;37.62;0.00;-2.82;0.00;30.10;30.00;27.10;20.20;-9999.00;54.58;1199;;;;;;30.60;36.10;24.47;29.31;0.00;12.00;0.00;80.00;29.84;-1000.00;-77.368;-54.088;33;2835.48;72.70;2;2.013
+M;0002;015;02;752;39.58;0.00;37.50;0.00;-2.79;0.00;30.00;30.00;27.10;20.20;-9999.00;54.61;1200;;;;;;30.60;36.10;24.47;29.31;0.00;12.00;0.00;80.00;29.83;-1000.00;-90.368;-54.088;33;2836.96;72.70;2;2.013
+M;0002;016;02;753;39.96;0.00;37.87;0.00;-2.78;0.00;30.10;30.00;27.20;20.20;-9999.00;54.61;1200;;;;;;30.60;36.10;24.47;29.31;0.00;12.00;0.00;80.00;29.83;-1000.00;-103.368;-54.088;33;2838.46;72.71;2;2.013
+M;0002;017;02;754;42.81;0.00;40.56;0.00;-2.80;0.00;30.10;30.00;27.20;20.20;-9999.00;54.61;1200;;;;;;30.60;36.10;24.44;29.31;0.00;12.00;0.00;80.00;29.84;-1000.00;-103.376;-41.096;33;2837.77;72.71;2;2.013
+M;0002;018;02;756;40.78;0.00;38.64;0.00;-2.77;0.00;30.00;30.00;27.20;20.20;-9999.00;54.60;1199;;;;;;30.60;36.10;24.53;29.31;0.00;12.00;0.00;80.00;29.85;-1000.00;-90.400;-41.096;33;2835.23;72.71;2;2.013
+M;0002;019;02;757;40.76;0.00;38.63;0.00;-2.80;0.00;30.00;30.00;27.20;20.20;-9999.00;54.64;1198;;;;;;30.70;36.10;24.53;29.31;0.00;12.00;0.00;80.00;29.85;-1000.00;-77.408;-41.096;33;2834.48;72.71;2;2.013
+M;0002;020;02;758;40.01;0.00;37.92;0.00;-2.79;0.00;30.00;30.00;27.20;20.20;-9999.00;54.63;1199;;;;;;30.70;36.10;24.56;29.31;0.00;12.00;0.00;80.00;29.84;-1000.00;-64.408;-41.096;33;2833.67;72.71;2;2.013
+M;0002;021;02;760;41.03;0.00;38.88;0.00;-2.80;0.00;30.10;30.00;27.20;20.20;-9999.00;54.66;1199;;;;;;30.70;36.10;24.53;29.31;0.00;12.00;0.00;80.00;29.85;-1000.00;-51.400;-41.096;33;2833.68;72.71;2;2.013
+M;0002;022;02;761;39.32;0.00;37.26;0.00;-2.79;0.00;30.10;30.00;27.20;20.20;-9999.00;54.67;1199;;;;;;30.70;36.10;24.53;29.31;0.00;12.00;0.00;80.00;29.85;-1000.00;-38.408;-41.096;33;2832.46;72.71;2;2.013
+M;0002;023;02;762;42.28;0.00;40.06;0.00;-2.81;0.00;30.10;30.00;27.20;20.20;-9999.00;54.66;1199;;;;;;30.70;36.10;24.47;29.31;0.00;12.00;0.00;80.00;29.85;-1000.00;-25.400;-41.096;33;2832.23;72.71;2;2.013
+M;0002;024;02;764;40.41;0.00;38.29;0.00;-2.78;0.00;30.10;30.00;27.20;20.20;-9999.00;54.68;1200;;;;;;30.70;36.20;24.50;29.31;0.00;11.50;0.00;80.00;29.85;-1000.00;-12.408;-41.096;33;2833.23;72.71;2;2.013
+M;0002;025;02;765;43.01;0.00;40.75;0.00;-2.82;0.00;30.00;30.00;27.20;20.20;-9999.00;54.65;1199;;;;;;30.70;36.20;24.50;29.31;0.00;11.50;0.00;80.00;29.85;-1000.00;-12.408;-28.112;33;2835.21;72.71;2;2.013
+M;0002;026;02;766;43.13;0.00;40.86;0.00;-2.81;0.00;30.00;30.00;27.20;20.20;-9999.00;54.67;1199;;;;;;30.70;36.20;24.53;29.31;0.00;11.50;0.00;80.00;29.85;-1000.00;-25.376;-28.112;33;2832.92;72.71;2;2.013
+M;0002;027;02;768;39.20;0.00;37.14;0.00;-2.79;0.00;30.10;30.00;27.20;20.20;-9999.00;54.71;1199;;;;;;30.70;36.20;24.53;29.31;0.00;12.00;0.00;80.00;29.85;-1000.00;-38.384;-28.112;33;2833.21;72.71;2;2.013
+M;0002;028;02;769;41.10;0.00;38.95;0.00;-2.78;0.00;30.00;30.00;27.20;20.20;-9999.00;54.77;1199;;;;;;30.80;36.20;24.53;29.31;0.00;11.50;0.00;80.00;29.86;-1000.00;-51.376;-28.112;33;2833.11;72.71;2;2.013
+M;0002;029;02;770;42.23;0.00;40.02;0.00;-2.80;0.00;30.00;30.00;27.20;20.20;-9999.00;54.78;1199;;;;;;30.80;36.20;24.50;29.31;0.00;11.50;0.00;80.00;29.86;-1000.00;-64.376;-28.112;33;2833.23;72.72;2;2.013
+M;0002;030;02;772;42.73;0.00;40.49;0.00;-2.78;0.00;30.00;30.00;27.20;20.20;-9999.00;54.77;1199;;;;;;30.80;36.20;24.53;29.31;0.00;11.50;0.00;80.00;29.86;-1000.00;-77.376;-28.112;33;2834.09;72.72;2;2.013
+M;0002;031;02;773;39.76;0.00;37.68;0.00;-2.80;0.00;30.10;30.00;27.20;20.20;-9999.00;54.79;1199;;;;;;30.80;36.20;24.53;29.31;0.00;12.00;0.00;80.00;29.86;-1000.00;-90.360;-28.112;33;2835.19;72.71;2;2.013
+M;0002;032;02;774;41.06;0.00;38.91;0.00;-2.78;0.00;30.00;30.00;27.20;20.20;-9999.00;54.80;1199;;;;;;30.80;36.20;24.56;29.38;0.00;11.50;0.00;80.00;29.86;-1000.00;-103.368;-28.112;33;2835.33;72.72;2;2.013
+P;0002;;;774;;;;;;;30.00;30.00;27.20;20.20;-9999.00;54.80;1199;;;;;;30.80;36.20;24.56;29.38;0.00;11.50;0.00;80.00;29.86;-1000.00;-103.368;-28.112;33;;;;2.015;1.335;1.084;1.069;1.319;
+P;0002;;;776;;;;;;;30.00;30.00;27.30;20.20;-9999.00;54.81;1199;;;;;;30.80;36.20;24.56;29.38;0.00;12.00;0.00;80.00;29.87;-1000.00;-103.368;-28.104;2;;;;2.015;1.333;1.083;1.068;1.320;
+M;0002;001;03;797;76.69;0.00;0.00;0.00;33.94;6.45;30.00;30.00;27.30;20.19;-9999.00;55.05;1200;;;;;;31.00;36.30;24.44;29.38;0.00;11.50;1.00;80.00;29.86;-1000.00;-99.416;-70.056;22;3479.96;72.02;4;2.015
+M;0002;002;03;798;78.18;0.00;0.00;0.00;33.39;6.48;30.00;30.00;27.30;20.18;-9999.00;55.05;1200;;;;;;31.00;36.30;24.47;29.38;0.00;11.50;1.00;80.00;29.87;-1000.00;-86.400;-70.056;22;3479.29;72.02;4;2.015
+M;0002;003;03;800;84.14;0.00;0.00;0.00;33.42;6.47;30.00;30.00;27.30;20.18;-9999.00;55.06;1200;;;;;;31.00;36.30;24.50;29.38;0.00;11.50;1.00;80.00;29.88;-1000.00;-73.408;-70.056;22;3478.34;72.02;4;2.015
+M;0002;004;03;801;79.06;0.00;0.00;0.00;33.08;6.49;30.00;30.00;27.30;20.18;-9999.00;55.06;1200;;;;;;31.00;36.30;24.50;29.38;0.00;12.00;1.50;80.00;29.88;-1000.00;-60.408;-70.056;22;3477.66;72.02;4;2.015
+M;0002;005;03;802;80.25;0.00;0.00;0.00;32.99;6.49;30.00;30.00;27.30;20.18;-9999.00;55.13;1200;;;;;;31.00;36.30;24.47;29.38;0.00;12.00;1.50;80.00;29.88;-1000.00;-47.400;-70.056;22;3477.38;72.02;4;2.015
+M;0002;006;03;804;80.49;0.00;0.00;0.00;33.31;6.48;30.00;30.00;27.30;20.18;-9999.00;55.14;1200;;;;;;31.10;36.30;24.50;29.38;0.00;12.00;1.00;80.00;29.88;-1000.00;-34.408;-70.056;22;3476.79;72.03;4;2.015
+M;0002;007;03;805;87.80;0.00;0.00;0.00;34.46;6.42;30.00;30.00;27.30;20.18;-9999.00;55.12;1200;;;;;;31.10;36.30;24.50;29.38;0.00;11.50;1.00;80.00;29.88;-1000.00;-21.400;-70.056;22;3476.94;72.02;4;2.015
+M;0002;008;03;806;77.11;0.00;0.00;0.00;32.31;6.53;30.00;30.00;27.40;20.18;-9999.00;55.18;1200;;;;;;31.10;36.30;24.50;29.38;0.00;12.00;0.50;80.00;29.88;-1000.00;-8.408;-70.056;22;3476.32;72.02;4;2.015
+M;0002;009;03;808;81.82;0.00;0.00;0.00;32.20;6.53;30.00;30.00;27.40;20.18;-9999.00;55.21;1198;;;;;;31.10;36.30;24.47;29.38;0.00;12.00;0.50;80.00;29.88;-1000.00;-8.408;-57.088;22;3476.95;72.01;4;2.015
+M;0002;010;03;809;84.96;0.00;0.00;0.00;33.32;6.48;30.00;30.00;27.40;20.18;-9999.00;55.22;1199;;;;;;31.10;36.30;24.47;29.38;0.00;12.00;0.50;80.00;29.88;-1000.00;-21.376;-57.088;22;3476.07;72.03;4;2.015
+M;0002;011;03;810;74.81;0.00;0.00;0.00;31.37;6.58;30.00;30.00;27.40;20.18;-9999.00;55.26;1199;;;;;;31.20;36.30;24.50;29.38;0.00;11.50;0.00;80.00;29.89;-1000.00;-34.376;-57.088;22;3476.09;72.03;4;2.015
+M;0002;012;03;812;78.49;0.00;0.00;0.00;32.26;6.53;30.00;30.00;27.40;20.17;-9999.00;55.28;1199;;;;;;31.20;36.30;24.50;29.38;0.00;11.50;0.00;80.00;29.90;-1000.00;-47.376;-57.088;22;3476.03;72.03;4;2.015
+M;0002;013;03;813;74.93;0.00;0.00;0.00;31.60;6.56;30.00;30.00;27.40;20.17;-9999.00;55.30;1199;;;;;;31.20;36.30;24.50;29.38;0.00;11.50;0.00;80.00;29.90;-1000.00;-60.376;-57.088;22;3475.92;72.03;4;2.015
+M;0002;014;03;814;74.03;0.00;0.00;0.00;31.79;6.55;30.00;30.00;27.40;20.17;-9999.00;55.30;1199;;;;;;31.20;36.30;24.50;29.38;0.00;12.00;0.00;80.00;29.90;-1000.00;-73.376;-57.088;22;3476.38;72.03;4;2.015
+M;0002;015;03;815;73.37;0.00;0.00;0.00;31.70;6.56;30.00;30.00;27.40;20.17;-9999.00;55.31;1199;;;;;;31.20;36.30;24.56;29.38;0.00;12.00;0.00;80.00;29.90;-1000.00;-86.368;-57.088;22;3476.62;72.03;4;2.015
+M;0002;016;03;817;77.64;0.00;0.00;0.00;33.54;6.47;30.00;30.00;27.40;20.17;-9999.00;55.33;1200;;;;;;31.20;36.30;24.56;29.38;0.00;11.50;0.00;80.00;29.91;-1000.00;-99.368;-57.088;22;3477.31;72.03;4;2.015
+M;0002;017;03;818;71.23;0.00;0.00;0.00;31.58;6.56;30.00;30.00;27.40;20.17;-9999.00;55.29;1200;;;;;;31.20;36.30;24.53;29.38;0.00;12.00;0.00;80.00;29.90;-1000.00;-99.368;-44.096;22;3476.62;72.04;4;2.015
+M;0002;018;03;819;83.44;0.00;0.00;0.00;33.16;6.49;30.00;30.00;27.40;20.17;-9999.00;55.31;1200;;;;;;31.20;36.30;24.53;29.38;0.00;12.00;0.00;80.00;29.90;-1000.00;-86.400;-44.096;22;3476.88;72.03;4;2.015
+M;0002;019;03;821;82.37;0.00;0.00;0.00;32.81;6.50;30.00;30.00;27.40;20.17;-9999.00;55.36;1199;;;;;;31.20;36.30;24.53;29.38;0.00;12.00;0.00;80.00;29.90;-1000.00;-73.408;-44.096;22;3476.62;72.02;4;2.015
+M;0002;020;03;822;84.65;0.00;0.00;0.00;33.30;6.48;30.00;30.00;27.40;20.17;-9999.00;55.39;1199;;;;;;31.30;36.30;24.50;29.38;0.00;11.50;-0.50;80.00;29.90;-1000.00;-60.408;-44.096;22;3475.68;72.03;4;2.015
+M;0002;021;03;823;90.43;0.00;0.00;0.00;33.81;6.45;30.00;30.00;27.40;20.17;-9999.00;55.39;1199;;;;;;31.30;36.30;24.50;29.38;0.00;11.50;-0.50;80.00;29.90;-1000.00;-47.400;-44.096;22;3475.38;72.03;4;2.015
+M;0002;022;03;825;86.11;0.00;0.00;0.00;33.35;6.48;30.00;30.00;27.40;20.17;-9999.00;55.43;1200;;;;;;31.30;36.30;24.56;29.38;0.00;11.50;-0.50;80.00;29.91;-1000.00;-34.408;-44.096;22;3475.29;72.04;4;2.015
+M;0002;023;03;826;86.73;0.00;0.00;0.00;33.25;6.48;30.00;30.00;27.50;20.17;-9999.00;55.44;1200;;;;;;31.30;36.30;24.56;29.44;0.00;11.00;-0.50;80.00;29.90;-1000.00;-21.408;-44.096;22;3475.07;72.04;4;2.015
+M;0002;024;03;828;92.22;0.00;0.00;0.00;33.94;6.45;30.00;30.00;27.50;20.17;-9999.00;55.48;1200;;;;;;31.30;36.30;24.50;29.44;0.00;11.00;-0.50;80.00;29.90;-1000.00;-8.408;-44.096;22;3475.60;72.03;4;2.015
+M;0002;025;03;829;94.84;0.00;0.00;0.00;34.73;6.41;30.00;30.00;27.50;20.17;-9999.00;55.46;1200;;;;;;31.30;36.30;24.50;29.44;0.00;11.50;-0.50;80.00;29.90;-1000.00;-8.408;-31.104;22;3475.93;72.04;4;2.015
+M;0002;026;03;830;82.65;0.00;0.00;0.00;32.95;6.50;30.00;30.00;27.50;20.17;-9999.00;55.47;1200;;;;;;31.30;36.30;24.53;29.44;0.00;12.00;-0.50;80.00;29.91;-1000.00;-21.376;-31.104;22;3474.58;72.04;4;2.015
+M;0002;027;03;831;98.16;0.00;0.00;0.00;35.36;6.38;30.00;30.00;27.50;20.17;-9999.00;55.47;1200;;;;;;31.30;36.30;24.47;29.44;0.00;12.00;-0.50;80.00;29.90;-1000.00;-34.376;-31.104;22;3476.68;72.05;4;2.015
+M;0002;028;03;833;82.33;0.00;0.00;0.00;33.21;6.48;30.00;30.00;27.50;20.17;-9999.00;55.50;1200;;;;;;31.40;36.30;24.47;29.44;0.00;12.00;-0.50;80.00;29.91;-1000.00;-47.376;-31.104;22;3476.70;72.04;4;2.015
+M;0002;029;03;834;80.10;0.00;0.00;0.00;32.78;6.51;30.00;30.00;27.50;20.17;-9999.00;55.51;1200;;;;;;31.40;36.40;24.53;29.44;0.00;11.50;-0.50;80.00;29.90;-1000.00;-60.376;-31.104;22;3476.32;72.04;4;2.015
+M;0002;030;03;835;78.98;0.00;0.00;0.00;32.32;6.53;30.00;30.00;27.50;20.17;-9999.00;55.53;1199;;;;;;31.40;36.40;24.53;29.44;0.00;11.50;-0.50;80.00;29.90;-1000.00;-73.376;-31.104;22;3476.38;72.04;4;2.015
+M;0002;031;03;837;76.85;0.00;0.00;0.00;32.42;6.52;30.00;30.00;27.50;20.17;-9999.00;55.55;1199;;;;;;31.40;36.40;24.56;29.44;0.00;12.00;-0.50;80.00;29.90;-1000.00;-86.368;-31.104;22;3476.92;72.05;4;2.015
+M;0002;032;03;838;70.62;0.00;0.00;0.00;31.50;6.57;30.00;30.00;27.50;20.17;-9999.00;55.53;1199;;;;;;31.40;36.40;24.53;29.44;0.00;12.00;-0.50;80.00;29.91;-1000.00;-99.368;-31.104;22;3477.17;72.05;4;2.015
+P;0002;;;838;;;;;;;30.00;30.00;27.50;20.17;-9999.00;55.53;1199;;;;;;31.40;36.40;24.53;29.44;0.00;12.00;-0.50;80.00;29.91;-1000.00;-99.368;-31.104;22;;;;2.014;1.331;1.083;1.069;1.313;
+P;0002;;;839;;;;;;;30.00;30.00;27.50;20.17;-9999.00;55.51;1199;;;;;;31.40;36.40;24.53;29.44;0.00;12.00;-0.50;80.00;29.91;-1000.00;-99.368;-31.104;1;;;;2.014;1.332;1.083;1.070;1.312;
+M;0002;001;04;861;31.85;0.00;0.00;0.00;36.49;127.01;30.00;30.00;27.60;20.17;-9999.00;56.00;1199;;;;;;31.60;36.40;24.53;29.44;0.00;11.00;0.00;80.00;29.94;-1000.00;-100.416;-65.584;22;2253.78;5.64;3;2.014
+M;0002;002;04;862;32.38;0.00;0.00;0.00;36.68;125.88;30.00;30.00;27.60;20.17;-9999.00;55.95;1200;;;;;;31.60;36.40;24.44;29.50;0.00;11.00;0.00;80.00;29.93;-1000.00;-87.400;-65.584;22;2252.19;5.70;3;2.014
+M;0002;003;04;864;33.31;0.00;0.00;0.00;37.02;123.91;30.00;30.00;27.60;20.17;-9999.00;55.92;1200;;;;;;31.60;36.40;24.56;29.50;0.00;10.50;0.00;80.00;29.93;-1000.00;-74.408;-65.584;22;2251.51;5.67;3;2.014
+M;0002;004;04;865;34.25;0.00;0.00;0.00;36.94;124.36;30.00;30.00;27.60;20.17;-9999.00;55.97;1200;;;;;;31.60;36.50;24.56;29.44;0.00;10.50;0.00;80.00;29.93;-1000.00;-61.408;-65.584;22;2251.50;5.64;3;2.014
+M;0002;005;04;866;31.98;0.00;0.00;0.00;36.73;125.58;30.00;30.00;27.60;20.17;-9999.00;55.98;1200;;;;;;31.70;36.50;24.53;29.50;0.00;11.00;0.00;80.00;29.93;-1000.00;-48.400;-65.584;22;2251.17;5.64;3;2.014
+M;0002;006;04;868;33.44;0.00;0.00;0.00;36.96;124.25;30.00;30.00;27.60;20.17;-9999.00;55.99;1200;;;;;;31.70;36.40;24.50;29.50;0.00;10.50;-0.50;80.00;29.93;-1000.00;-35.408;-65.584;22;2250.23;5.68;3;2.014
+M;0002;007;04;869;32.76;0.00;0.00;0.00;36.72;125.62;30.00;30.00;27.60;20.17;-9999.00;55.96;1199;;;;;;31.70;36.40;24.50;29.50;0.00;10.50;-0.50;80.00;29.94;-1000.00;-22.400;-65.584;22;2249.89;5.62;3;2.014
+M;0002;008;04;870;33.29;0.00;0.00;0.00;36.76;125.41;30.00;30.00;27.60;20.17;-9999.00;56.05;1200;;;;;;31.70;36.40;24.59;29.50;0.00;10.50;-0.50;80.00;29.93;-1000.00;-9.408;-65.584;22;2249.01;5.71;3;2.014
+M;0002;009;04;872;31.05;0.00;0.00;0.00;36.20;128.73;30.00;30.00;27.70;20.17;-9999.00;56.07;1200;;;;;;31.70;36.50;24.53;29.50;0.00;10.50;-0.50;80.00;29.94;-1000.00;-9.408;-52.584;22;2249.53;5.70;3;2.014
+M;0002;010;04;873;32.74;0.00;0.00;0.00;36.63;126.17;30.00;30.00;27.70;20.17;-9999.00;56.11;1200;;;;;;31.70;36.50;24.53;29.50;0.00;10.50;-0.50;80.00;29.94;-1000.00;-22.368;-52.584;22;2248.88;5.72;3;2.014
+M;0002;011;04;874;31.06;0.00;0.00;0.00;36.41;127.45;30.00;30.00;27.70;20.17;-9999.00;56.13;1200;;;;;;31.70;36.50;24.53;29.50;0.00;11.00;-1.00;80.00;29.95;-1000.00;-35.384;-52.584;22;2248.17;5.69;3;2.014
+M;0002;012;04;876;31.39;0.00;0.00;0.00;36.16;128.99;30.00;30.00;27.70;20.16;-9999.00;56.15;1200;;;;;;31.80;36.50;24.50;29.50;0.00;10.50;-1.00;80.00;29.95;-1000.00;-48.376;-52.584;22;2248.30;5.63;3;2.014
+M;0002;013;04;877;32.28;0.00;0.00;0.00;36.61;126.29;30.00;30.00;27.70;20.16;-9999.00;56.19;1199;;;;;;31.80;36.50;24.50;29.50;0.00;10.50;-1.00;80.00;29.95;-1000.00;-61.376;-52.584;22;2248.17;5.65;3;2.014
+M;0002;014;04;878;34.12;0.00;0.00;0.00;36.77;125.36;30.00;30.00;27.70;20.16;-9999.00;56.20;1199;;;;;;31.80;36.50;24.53;29.50;0.00;10.00;-1.00;80.00;29.95;-1000.00;-74.376;-52.584;22;2248.38;5.65;3;2.014
+M;0002;015;04;880;34.12;0.00;0.00;0.00;36.87;124.77;30.00;30.00;27.70;20.16;-9999.00;56.19;1199;;;;;;31.80;36.50;24.53;29.50;0.00;10.00;-1.00;80.00;29.96;-1000.00;-87.368;-52.584;22;2248.78;5.69;3;2.014
+M;0002;016;04;881;35.36;0.00;0.00;0.00;36.90;124.60;30.00;30.00;27.70;20.16;-9999.00;56.22;1199;;;;;;31.80;36.50;24.53;29.50;0.00;10.00;-1.00;80.00;29.96;-1000.00;-100.368;-52.584;22;2249.12;5.69;3;2.014
+M;0002;017;04;882;34.51;0.00;0.00;0.00;36.68;125.87;30.00;30.00;27.70;20.16;-9999.00;56.25;1199;;;;;;31.80;36.50;24.38;29.50;0.00;10.50;-1.00;80.00;29.96;-1000.00;-100.368;-39.600;22;2248.76;5.70;3;2.014
+M;0002;018;04;884;34.87;0.00;0.00;0.00;36.66;125.99;30.00;30.00;27.70;20.16;-9999.00;56.21;1199;;;;;;31.80;36.50;24.47;29.50;0.00;10.00;-1.50;80.00;29.96;-1000.00;-87.400;-39.600;22;2247.58;5.72;3;2.014
+M;0002;019;04;885;33.88;0.00;0.00;0.00;36.49;127.01;30.00;30.00;27.70;20.16;-9999.00;56.21;1199;;;;;;31.80;36.50;24.47;29.50;0.00;10.00;-1.50;80.00;29.96;-1000.00;-74.408;-39.600;22;2247.73;5.64;3;2.014
+M;0002;020;04;886;32.76;0.00;0.00;0.00;36.04;129.69;30.00;30.00;27.70;20.16;-9999.00;56.24;1199;;;;;;31.90;36.50;24.47;29.50;0.00;10.00;-1.50;80.00;29.96;-1000.00;-61.408;-39.600;22;2247.40;5.61;3;2.014
+M;0002;021;04;888;31.06;0.00;0.00;0.00;35.85;130.85;30.00;30.00;27.70;20.16;-9999.00;56.24;1200;;;;;;31.90;36.50;24.50;29.50;0.00;10.50;-1.50;80.00;29.96;-1000.00;-48.400;-39.600;22;2246.42;5.62;3;2.014
+M;0002;022;04;889;29.83;0.00;0.00;0.00;35.48;133.16;30.00;30.00;27.70;20.16;-9999.00;56.24;1199;;;;;;31.90;36.50;24.50;29.50;0.00;10.50;-1.50;80.00;29.97;-1000.00;-35.416;-39.600;22;2245.94;5.63;3;2.014
+M;0002;023;04;890;31.02;0.00;0.00;0.00;36.26;128.41;30.00;30.00;27.70;20.16;-9999.00;56.24;1199;;;;;;31.90;36.50;24.53;29.50;0.00;10.00;-1.50;80.00;29.96;-1000.00;-22.400;-39.600;22;2245.85;5.69;3;2.014
+M;0002;024;04;892;31.13;0.00;0.00;0.00;36.00;129.94;30.00;30.00;27.70;20.16;-9999.00;56.26;1199;;;;;;31.90;36.50;24.59;29.50;0.00;10.00;-1.50;80.00;29.96;-1000.00;-9.408;-39.600;22;2246.48;5.64;3;2.014
+M;0002;025;04;893;35.53;0.00;0.00;0.00;36.35;127.86;30.00;30.00;27.70;20.16;-9999.00;56.25;1199;;;;;;31.90;36.50;24.59;29.50;0.00;10.00;-1.50;80.00;29.96;-1000.00;-9.408;-26.600;22;2246.88;5.67;3;2.014
+M;0002;026;04;894;34.67;0.00;0.00;0.00;36.44;127.32;30.00;30.00;27.80;20.16;-9999.00;56.27;1199;;;;;;32.00;36.50;24.53;29.50;0.00;10.00;-1.50;80.00;29.97;-1000.00;-22.376;-26.600;22;2245.47;5.66;3;2.014
+M;0002;027;04;896;34.62;0.00;0.00;0.00;36.41;127.48;30.00;30.00;27.80;20.15;-9999.00;56.26;1200;;;;;;32.00;36.50;24.50;29.50;0.00;10.00;-1.50;80.00;29.98;-1000.00;-35.384;-26.600;22;2246.34;5.64;3;2.014
+M;0002;028;04;897;36.00;0.00;0.00;0.00;36.44;127.29;30.00;30.00;27.80;20.15;-9999.00;56.28;1199;;;;;;32.00;36.50;24.50;29.50;0.00;10.00;-1.50;80.00;29.98;-1000.00;-48.376;-26.600;22;2246.05;5.67;3;2.014
+M;0002;029;04;898;36.59;0.00;0.00;0.00;36.73;125.60;30.00;30.00;27.80;20.15;-9999.00;56.31;1199;;;;;;32.00;36.50;24.50;29.50;0.00;10.50;-1.50;80.00;29.97;-1000.00;-61.376;-26.600;22;2245.99;5.71;3;2.014
+M;0002;030;04;900;36.57;0.00;0.00;0.00;36.78;125.26;30.00;30.00;27.80;20.15;-9999.00;56.34;1199;;;;;;32.00;36.50;24.53;29.50;0.00;10.50;-1.50;80.00;29.98;-1000.00;-74.376;-26.600;22;2246.46;5.65;3;2.014
+M;0002;031;04;901;37.46;0.00;0.00;0.00;36.86;124.84;30.00;30.00;27.80;20.15;-9999.00;56.34;1200;;;;;;32.00;36.50;24.53;29.50;0.00;10.50;-1.50;80.00;29.98;-1000.00;-87.368;-26.600;22;2247.66;5.63;3;2.014
+M;0002;032;04;902;36.31;0.00;0.00;0.00;36.79;125.24;30.00;30.00;27.80;20.14;-9999.00;56.36;1200;;;;;;32.00;36.50;24.53;29.50;0.00;10.50;-1.50;80.00;29.97;-1000.00;-100.368;-26.600;22;2247.74;5.68;3;2.014
+P;0002;;;902;;;;;;;30.00;30.00;27.80;20.14;-9999.00;56.36;1200;;;;;;32.00;36.50;24.53;29.50;0.00;10.50;-1.50;80.00;29.97;-1000.00;-100.368;-26.600;22;;;;2.014;1.329;1.082;1.070;1.306;
+P;0002;;;904;;;;;;;30.00;30.00;27.80;20.14;-9999.00;56.34;1200;;;;;;32.10;36.50;24.53;29.50;0.00;11.00;-1.50;80.00;29.98;-1000.00;-100.368;-26.600;2;;;;2.014;1.330;1.083;1.070;1.306;
+R;0002;;05;917;-9999.00;0.00;;;;;30.00;30.00;27.90;20.13;-9999.00;56.45;1200;LED;;;;;32.20;36.60;24.53;29.56;0.00;9.50;-1.50;80.00;29.98;-1000.00;-124.864;-69.552;11;8192.00;0.00;0;2.014
+M;0002;001;05;922;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;27.90;20.13;-9999.00;56.52;1200;;;;;;32.20;36.60;24.56;29.56;0.00;10.00;-0.50;80.00;29.98;-1000.00;-103.408;-67.088;16;8192.00;0.00;0;2.014
+M;0002;002;05;927;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;27.90;20.13;-9999.00;56.57;1200;;;;;;32.30;36.60;24.62;29.56;0.00;10.50;-0.50;80.00;29.98;-1000.00;-90.400;-67.088;16;8192.00;0.00;0;2.014
+M;0002;003;05;931;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;27.90;20.13;-9999.00;56.63;1199;;;;;;32.40;36.60;24.50;29.56;0.00;10.00;-1.00;80.00;29.99;-1000.00;-77.408;-67.088;16;8192.00;0.00;0;2.014
+M;0002;004;05;935;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.00;20.13;-9999.00;56.65;1199;;;;;;32.40;36.60;24.53;29.56;0.00;10.00;-1.50;80.00;29.99;-1000.00;-64.400;-67.088;16;8192.00;0.00;0;2.014
+M;0002;005;05;940;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.00;20.13;-9999.00;56.65;1199;;;;;;32.40;36.60;24.56;29.56;0.00;10.50;-2.00;80.00;29.99;-1000.00;-51.400;-67.088;16;8192.00;0.00;0;2.014
+M;0002;006;05;944;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.00;20.12;-9999.00;56.70;1200;;;;;;32.50;36.60;24.56;29.56;0.00;10.50;-2.00;80.00;29.99;-1000.00;-38.408;-67.088;16;8192.00;0.00;0;2.014
+M;0002;007;05;949;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.00;20.12;-9999.00;56.71;1199;;;;;;32.50;36.60;24.53;29.56;0.00;10.50;-2.00;80.00;29.99;-1000.00;-25.400;-67.088;16;8192.00;0.00;0;2.014
+M;0002;008;05;953;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.00;20.12;-9999.00;56.85;1199;;;;;;32.60;36.60;24.53;29.56;0.00;10.50;-2.50;80.00;30.00;-1000.00;-12.408;-67.088;16;8192.00;0.00;0;2.014
+M;0002;009;05;958;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.10;20.12;-9999.00;56.81;1200;;;;;;32.60;36.60;24.59;29.56;0.00;10.50;-2.50;80.00;30.00;-1000.00;-12.408;-54.088;16;8192.00;0.00;0;2.014
+M;0002;010;05;962;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.10;20.11;-9999.00;56.88;1200;;;;;;32.70;36.60;24.50;29.56;0.00;10.50;-2.50;80.00;30.01;-1000.00;-25.376;-54.088;16;8192.00;0.00;0;2.014
+M;0002;011;05;967;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.10;20.11;-9999.00;56.92;1199;;;;;;32.70;36.60;24.53;29.56;0.00;10.50;-2.50;80.00;30.00;-1000.00;-38.384;-54.088;16;8192.00;0.00;0;2.014
+M;0002;012;05;971;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.10;20.10;-9999.00;56.99;1199;;;;;;32.70;36.60;24.53;29.62;0.00;10.50;-2.50;80.00;30.02;-1000.00;-51.376;-54.088;16;8192.00;0.00;0;2.014
+M;0002;013;05;975;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.10;20.10;-9999.00;57.04;1198;;;;;;32.80;36.60;24.59;29.62;0.00;10.50;-3.00;80.00;30.02;-1000.00;-64.376;-54.088;16;8192.00;0.00;0;2.014
+M;0002;014;05;980;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.20;20.10;-9999.00;57.10;1201;;;;;;32.80;36.70;24.56;29.62;0.00;10.00;-3.00;80.00;30.02;-1000.00;-77.368;-54.088;16;8192.00;0.00;0;2.014
+M;0002;015;05;984;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.20;20.10;-9999.00;57.18;1200;;;;;;32.90;36.70;24.59;29.62;0.00;9.50;-3.50;80.00;30.02;-1000.00;-90.360;-54.088;16;8192.00;0.00;0;2.014
+M;0002;016;05;989;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.20;20.10;-9999.00;57.22;1200;;;;;;32.90;36.70;24.59;29.62;0.00;9.50;-3.50;80.00;30.02;-1000.00;-103.368;-54.088;16;8192.00;0.00;0;2.014
+M;0002;017;05;993;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.20;20.10;-9999.00;57.24;1199;;;;;;33.00;36.70;24.53;29.62;0.00;9.50;-3.50;80.00;30.02;-1000.00;-103.368;-41.104;16;8192.00;0.00;0;2.014
+M;0002;018;05;998;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.30;20.10;-9999.00;57.45;1199;;;;;;33.00;36.70;24.47;29.62;0.00;9.00;-3.00;80.00;30.04;-1000.00;-90.400;-41.096;16;8192.00;0.00;0;2.014
+M;0002;019;05;1002;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.30;20.09;-9999.00;57.41;1200;;;;;;33.10;36.70;24.56;29.62;0.00;9.00;-3.00;80.00;30.03;-1000.00;-77.408;-41.096;16;8192.00;0.00;0;2.014
+M;0002;020;05;1007;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.30;20.09;-9999.00;57.50;1199;;;;;;33.10;36.80;24.59;29.62;0.00;9.00;-3.50;80.00;30.04;-1000.00;-64.408;-41.096;16;8192.00;0.00;0;2.014
+M;0002;021;05;1011;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.30;20.09;-9999.00;57.54;1199;;;;;;33.10;36.70;24.59;29.62;0.00;9.50;-3.00;80.00;30.03;-1000.00;-51.400;-41.096;16;8192.00;0.00;0;2.014
+M;0002;022;05;1016;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.40;20.09;-9999.00;57.63;1199;;;;;;33.20;36.70;24.53;29.62;0.00;9.00;-3.00;80.00;30.04;-1000.00;-38.408;-41.096;16;8192.00;0.00;0;2.014
+M;0002;023;05;1020;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.40;20.09;-9999.00;57.59;1200;;;;;;33.20;36.80;24.56;29.62;0.00;8.50;-3.50;80.00;30.04;-1000.00;-25.400;-41.096;16;8192.00;0.00;0;2.014
+M;0002;024;05;1024;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.40;20.09;-9999.00;57.61;1199;;;;;;33.30;36.80;24.53;29.69;0.00;8.50;-3.50;80.00;30.05;-1000.00;-12.408;-41.096;16;8192.00;0.00;0;2.014
+M;0002;025;05;1029;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.40;20.09;-9999.00;57.64;1200;;;;;;33.30;36.80;24.50;29.69;0.00;9.00;-3.50;80.00;30.06;-1000.00;-12.408;-28.104;16;8192.00;0.00;0;2.014
+M;0002;026;05;1033;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.50;20.08;-9999.00;57.72;1199;;;;;;33.40;36.80;24.53;29.69;0.00;8.50;-3.50;80.00;30.06;-1000.00;-25.376;-28.104;16;8192.00;0.00;0;2.014
+M;0002;027;05;1038;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.50;20.08;-9999.00;57.74;1199;;;;;;33.40;36.80;24.56;29.69;0.00;8.50;-3.50;80.00;30.06;-1000.00;-38.384;-28.104;16;8192.00;0.00;0;2.014
+M;0002;028;05;1042;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.50;20.08;-9999.00;57.78;1200;;;;;;33.50;36.80;24.53;29.69;0.00;9.00;-3.50;80.00;30.06;-1000.00;-51.376;-28.104;16;8192.00;0.00;0;2.014
+M;0002;029;05;1047;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.50;20.08;-9999.00;57.84;1200;;;;;;33.50;36.80;24.56;29.69;0.00;9.50;-3.50;80.00;30.07;-1000.00;-64.376;-28.104;16;8192.00;0.00;0;2.014
+M;0002;030;05;1051;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.60;20.07;-9999.00;57.91;1199;;;;;;33.50;36.80;24.47;29.69;0.00;9.50;-3.50;80.00;30.07;-1000.00;-77.376;-28.104;16;8192.00;0.00;0;2.014
+M;0002;031;05;1055;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.60;20.07;-9999.00;57.91;1200;;;;;;33.60;36.80;24.59;29.69;0.00;9.00;-3.50;80.00;30.08;-1000.00;-90.360;-28.104;16;8192.00;0.00;0;2.014
+M;0002;032;05;1060;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.60;20.07;-9999.00;58.01;1199;;;;;;33.70;36.80;24.53;29.69;0.00;9.00;-4.00;80.00;30.08;-1000.00;-103.368;-28.104;16;8192.00;0.00;0;2.014
+P;0002;;;1060;;;;;;;30.00;30.00;28.60;20.07;-9999.00;58.01;1199;#;;;;;33.70;36.80;24.53;29.69;0.00;9.00;-4.00;80.00;30.08;-1000.00;-103.368;-28.104;16;;;;2.014;1.329;1.081;1.071;1.321;
+P;0002;;;1060;;;;;;;30.00;30.00;28.60;20.07;-9999.00;58.02;1199;;;;;;33.70;36.80;24.53;29.69;0.00;9.00;-4.00;80.00;30.07;-1000.00;-103.368;-28.104;0;;;;2.014;1.329;1.081;1.071;1.321;
+R;0002;;06;1075;-9999.00;0.00;;;;;30.00;30.00;28.70;20.06;-9999.00;58.07;1200;LED;;;;;33.80;36.80;24.53;29.69;0.00;9.00;-3.50;80.00;30.09;-1000.00;-124.864;-69.552;11;8192.00;0.00;0;2.014
+M;0002;001;06;1080;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.70;20.06;-9999.00;58.14;1199;;;;;;33.90;36.80;24.66;29.75;0.00;9.00;-2.50;80.00;30.09;-1000.00;-103.408;-67.088;16;8192.00;0.00;0;2.014
+M;0002;002;06;1085;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.80;20.06;-9999.00;58.15;1200;;;;;;33.90;36.90;24.59;29.75;0.00;9.00;-2.50;80.00;30.09;-1000.00;-90.400;-67.088;16;8192.00;0.00;0;2.014
+M;0002;003;06;1089;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.80;20.06;-9999.00;58.20;1200;;;;;;33.90;36.80;24.59;29.75;0.00;9.00;-3.00;80.00;30.09;-1000.00;-77.408;-67.088;16;8192.00;0.00;0;2.014
+M;0002;004;06;1093;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.80;20.06;-9999.00;58.34;1199;;;;;;34.00;36.90;24.56;29.75;0.00;9.00;-3.50;80.00;30.09;-1000.00;-64.408;-67.088;16;8192.00;0.00;0;2.014
+M;0002;005;06;1098;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.80;20.05;-9999.00;58.38;1199;;;;;;34.00;36.90;24.50;29.75;0.00;9.00;-4.00;80.00;30.09;-1000.00;-51.400;-67.088;16;8192.00;0.00;0;2.014
+M;0002;006;06;1102;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.90;20.05;-9999.00;58.45;1199;;;;;;34.10;36.90;24.56;29.75;0.00;9.00;-4.50;80.00;30.09;-1000.00;-38.408;-67.088;16;8192.00;0.00;0;2.014
+M;0002;007;06;1107;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.90;20.05;-9999.00;58.55;1199;;;;;;34.10;36.90;24.53;29.75;0.00;9.00;-4.50;80.00;30.09;-1000.00;-25.400;-67.088;16;8192.00;0.00;0;2.014
+M;0002;008;06;1111;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;28.90;20.05;-9999.00;58.61;1199;;;;;;34.20;36.90;24.53;29.81;0.00;9.00;-4.50;80.00;30.11;-1000.00;-12.408;-67.088;16;8192.00;0.00;0;2.014
+M;0002;009;06;1115;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.00;20.05;-9999.00;58.62;1200;;;;;;34.20;36.90;24.62;29.81;0.00;9.00;-5.00;80.00;30.11;-1000.00;-12.408;-54.088;16;8192.00;0.00;0;2.014
+M;0002;010;06;1120;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.00;20.04;-9999.00;58.71;1200;;;;;;34.30;36.90;24.62;29.81;0.00;9.00;-5.00;80.00;30.11;-1000.00;-25.376;-54.088;16;8192.00;0.00;0;2.014
+M;0002;011;06;1124;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.00;20.05;-9999.00;58.78;1200;;;;;;34.30;37.00;24.59;29.81;0.00;9.00;-5.00;80.00;30.10;-1000.00;-38.384;-54.088;16;8192.00;0.00;0;2.014
+M;0002;012;06;1129;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.00;20.04;-9999.00;58.82;1200;;;;;;34.40;37.00;24.56;29.81;0.00;8.50;-5.50;80.00;30.11;-1000.00;-51.376;-54.088;16;8192.00;0.00;0;2.014
+M;0002;013;06;1133;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.00;20.03;-9999.00;58.82;1200;;;;;;34.50;37.00;24.56;29.81;0.00;8.50;-5.50;80.00;30.11;-1000.00;-64.376;-54.088;16;8192.00;0.00;0;2.014
+M;0002;014;06;1138;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.10;20.03;-9999.00;58.93;1199;;;;;;34.50;37.00;24.56;29.81;0.00;8.50;-5.50;80.00;30.11;-1000.00;-77.368;-54.088;16;8192.00;0.00;0;2.014
+M;0002;015;06;1142;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.10;20.03;-9999.00;58.94;1200;;;;;;34.60;37.00;24.53;29.81;0.00;9.00;-6.00;80.00;30.11;-1000.00;-90.368;-54.088;16;8192.00;0.00;0;2.014
+M;0002;016;06;1146;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.10;20.03;-9999.00;58.98;1199;;;;;;34.60;37.00;24.62;29.81;0.00;8.50;-6.50;80.00;30.12;-1000.00;-103.368;-54.088;16;8192.00;0.00;0;2.014
+M;0002;017;06;1151;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.20;20.03;-9999.00;59.03;1199;;;;;;34.70;37.00;24.53;29.81;0.00;8.50;-5.50;80.00;30.12;-1000.00;-103.368;-41.096;16;8192.00;0.00;0;2.014
+M;0002;018;06;1155;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.20;20.03;-9999.00;59.07;1200;;;;;;34.70;37.00;24.56;29.81;0.00;8.50;-5.50;80.00;30.12;-1000.00;-90.400;-41.096;16;8192.00;0.00;0;2.014
+M;0002;019;06;1160;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.20;20.02;-9999.00;59.14;1200;;;;;;34.80;37.00;24.53;29.81;0.00;8.50;-6.00;80.00;30.12;-1000.00;-77.408;-41.096;16;8192.00;0.00;0;2.014
+M;0002;020;06;1164;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.20;20.02;-9999.00;59.21;1199;;;;;;34.80;37.00;24.56;29.81;0.00;8.50;-5.50;80.00;30.12;-1000.00;-64.408;-41.096;16;8192.00;0.00;0;2.014
+M;0002;021;06;1168;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.30;20.02;-9999.00;59.28;1200;;;;;;34.90;37.00;24.62;29.88;0.00;8.00;-6.00;80.00;30.12;-1000.00;-51.400;-41.096;16;8192.00;0.00;0;2.014
+M;0002;022;06;1173;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.30;20.02;-9999.00;59.35;1199;;;;;;34.90;37.00;24.56;29.81;0.00;8.50;-6.00;80.00;30.13;-1000.00;-38.408;-41.096;16;8192.00;0.00;0;2.014
+M;0002;023;06;1177;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.30;20.02;-9999.00;59.42;1198;;;;;;35.00;37.00;24.56;29.88;0.00;8.00;-6.00;80.00;30.13;-1000.00;-25.400;-41.096;16;8192.00;0.00;0;2.014
+M;0002;024;06;1182;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.30;20.02;-9999.00;59.50;1201;;;;;;35.00;37.00;24.62;29.88;0.00;8.50;-6.00;80.00;30.13;-1000.00;-12.408;-41.096;16;8192.00;0.00;0;2.014
+M;0002;025;06;1186;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.40;20.03;-9999.00;59.53;1202;;;;;;35.00;37.00;24.62;29.88;0.00;8.50;-6.00;80.00;30.14;-1000.00;-12.408;-28.104;16;8192.00;0.00;0;2.014
+M;0002;026;06;1191;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.40;20.03;-9999.00;59.62;1200;;;;;;35.10;37.00;24.62;29.88;0.00;8.50;-6.00;80.00;30.15;-1000.00;-25.376;-28.104;16;8192.00;0.00;0;2.014
+M;0002;027;06;1195;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.40;20.03;-9999.00;59.61;1199;;;;;;35.20;37.00;24.56;29.88;0.00;8.00;-6.50;80.00;30.15;-1000.00;-38.384;-28.104;16;8192.00;0.00;0;2.014
+M;0002;028;06;1199;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.50;20.03;-9999.00;59.65;1199;;;;;;35.20;37.00;24.59;29.88;0.00;8.00;-6.50;80.00;30.15;-1000.00;-51.376;-28.104;16;8192.00;0.00;0;2.014
+M;0002;029;06;1204;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.50;20.03;-9999.00;59.76;1199;;;;;;35.30;37.00;24.59;29.88;0.00;8.00;-6.50;80.00;30.14;-1000.00;-64.376;-28.104;16;8192.00;0.00;0;2.014
+M;0002;030;06;1208;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.50;20.02;-9999.00;59.81;1199;;;;;;35.30;37.10;24.62;29.88;0.00;8.00;-6.50;80.00;30.15;-1000.00;-77.376;-28.104;16;8192.00;0.00;0;2.014
+M;0002;031;06;1213;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.50;20.02;-9999.00;59.83;1200;;;;;;35.30;37.10;24.59;29.88;0.00;8.00;-6.50;80.00;30.15;-1000.00;-90.360;-28.104;16;8192.00;0.00;0;2.014
+M;0002;032;06;1217;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;29.60;20.02;-9999.00;59.88;1199;;;;;;35.40;37.10;24.50;29.94;0.00;8.00;-7.00;80.00;30.15;-1000.00;-103.368;-28.104;16;8192.00;0.00;0;2.014
+P;0002;;;1217;;;;;;;30.00;30.00;29.60;20.02;-9999.00;59.88;1199;#;;;;;35.40;37.10;24.50;29.94;0.00;8.00;-7.00;80.00;30.15;-1000.00;-103.368;-28.104;16;;;;2.014;1.327;1.080;1.071;1.309;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 0 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 0 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 0 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 1 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 1 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 1 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 2 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 2 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 2 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 3 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 3 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 3 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 4 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 4 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 4 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 5 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 5 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 5 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 6 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 6 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 6 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 7 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 7 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;pH restart of module 1 and block 7 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 0 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 0 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 0 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 1 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 1 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 1 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 2 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 2 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 2 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 3 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 3 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 3 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 4 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 4 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 4 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 5 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 5 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 5 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 6 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 6 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 6 -- ucResetTimeFeeding_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 7 -- ucEnableWell  = 15;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 7 -- ucKeepLastCmd_Well  = 0;;;;
+C;0002;;;1223;;;;;;;;;;;;;;;ph start of module 0 and block 7 -- ucResetTimeFeeding_Well  = 0;;;;
+F;0002;001;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;016;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;017;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;032;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;002;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;015;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;018;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;031;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;003;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;014;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;019;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;030;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;004;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;013;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;020;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;029;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;005;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;012;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;021;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;028;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;006;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;011;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;022;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;027;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;007;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;010;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;023;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;026;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;008;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;009;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;024;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;025;;1225;;;;;;;;;;;;;;;;;-1;0.000;1000.000;
+F;0002;001;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;016;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;017;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;032;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;002;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;015;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;018;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;031;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;003;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;014;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;019;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;030;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;004;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;013;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;020;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;029;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;005;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;012;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;021;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;028;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;006;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;011;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;022;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;027;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;007;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;010;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;023;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;026;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;008;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;009;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;024;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;025;;1225;;;;;;;;;;;;;;;;;01;0.000;1000.000;
+F;0002;001;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;016;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;017;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;032;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;002;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;015;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;018;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;031;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;003;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;014;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;019;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;030;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;004;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;013;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;020;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;029;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;005;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;012;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;021;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;028;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;006;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;011;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;022;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;027;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;007;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;010;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;023;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;026;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;008;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;009;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;024;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+F;0002;025;;1225;;;;;;;;;;;;;;;;;02;0.000;1000.000;
+P;0122;;;72998;;;;;;;30.00;29.90;33.20;20.11;-9999.00;85.56;1200;;;;;;43.50;40.10;27.41;34.38;0.00;2.50;-37.50;0.00;30.13;-1000.00;-124.864;-69.552;16;;;;1.985;1.337;1.071;1.055;1.326;
+P;0122;;;72999;;;;;;;30.00;29.90;33.30;20.11;-9999.00;85.59;1200;;;;;;43.40;40.10;27.41;34.31;0.00;2.50;-37.50;0.00;30.14;-1000.00;-124.864;-69.552;1;;;;2.012;1.337;1.071;1.055;1.319;
+R;0122;;01;73029;214.13;0.00;;;;;30.00;29.80;33.10;20.11;-9999.00;85.22;1200;2747.90;;;;;43.50;40.10;27.38;34.31;0.00;2.50;-35.00;80.00;30.14;-1000.00;-124.864;-69.552;30;2747.90;72.80;2;2.012
+M;0122;001;01;73031;71.25;0.00;67.74;0.00;-2.72;0.00;30.00;29.80;33.10;20.11;-9999.00;85.32;1200;#;;;;;43.50;40.10;27.38;34.38;0.00;2.50;-35.00;80.00;30.15;-1000.00;-103.408;-67.096;32;2749.43;72.79;2;2.012
+M;0122;002;01;73032;68.21;0.00;64.85;0.00;-2.74;0.00;30.00;29.80;33.20;20.11;-9999.00;85.37;1200;;;;;;43.60;40.20;27.31;34.31;0.00;2.50;-34.00;80.00;30.14;-1000.00;-90.400;-67.096;32;2744.64;72.78;2;2.012
+M;0122;003;01;73033;57.96;0.00;55.11;0.00;-2.73;0.00;30.00;29.80;33.30;20.11;-9999.00;85.50;1200;;;;;;43.60;40.20;27.31;34.31;0.00;2.00;-34.00;80.00;30.14;-1000.00;-77.408;-67.096;32;2741.30;72.78;2;2.012
+M;0122;004;01;73035;69.76;0.00;66.33;0.00;-2.76;0.00;30.00;29.90;33.30;20.11;-9999.00;85.57;1200;;;;;;43.60;40.20;27.31;34.38;0.00;2.00;-34.50;0.00;30.15;-1000.00;-64.408;-67.088;32;2739.81;72.78;2;2.012
+M;0122;005;01;73036;60.29;0.00;57.32;0.00;-2.76;0.00;30.00;29.90;33.30;20.11;-9999.00;85.62;1199;;;;;;43.60;40.20;27.41;34.38;0.00;2.00;-34.50;0.00;30.15;-1000.00;-51.400;-67.088;32;2738.26;72.78;2;2.012
+M;0122;006;01;73037;63.16;0.00;60.04;0.00;-2.76;0.00;30.00;29.90;33.30;20.11;-9999.00;85.62;1199;;;;;;43.40;40.20;27.41;34.38;0.00;2.00;-35.00;0.00;30.14;-1000.00;-38.408;-67.088;32;2735.65;72.78;2;2.012
+M;0122;007;01;73038;69.62;0.00;66.19;0.00;-2.78;0.00;30.00;29.90;33.30;20.11;-9999.00;85.56;1199;;;;;;43.40;40.20;27.41;34.31;0.00;2.00;-35.00;0.00;30.14;-1000.00;-25.400;-67.088;32;2734.13;72.78;2;2.012
+M;0122;008;01;73040;69.24;0.00;65.83;0.00;-2.78;0.00;30.00;29.90;33.20;20.11;-9999.00;85.49;1199;;;;;;43.40;40.20;27.31;34.38;0.00;2.50;-36.00;0.00;30.15;-1000.00;-12.408;-67.088;32;2730.26;72.78;2;2.012
+M;0122;009;01;73041;72.94;0.00;69.34;0.00;-2.78;0.00;30.00;29.90;33.20;20.11;-9999.00;85.44;1199;;;;;;43.40;40.20;27.38;34.38;0.00;2.50;-36.50;0.00;30.14;-1000.00;-12.408;-54.080;32;2732.27;72.78;2;2.012
+M;0122;010;01;73042;66.20;0.00;62.94;0.00;-2.77;0.00;30.00;29.90;33.20;20.11;-9999.00;85.37;1199;;;;;;43.40;40.20;27.38;34.38;0.00;2.50;-36.50;0.00;30.15;-1000.00;-25.376;-54.080;32;2732.03;72.78;2;2.012
+M;0122;011;01;73044;59.42;0.00;56.49;0.00;-2.77;0.00;30.00;29.90;33.00;20.11;-9999.00;85.25;1200;;;;;;43.30;40.20;27.38;34.38;0.00;2.50;-36.50;0.00;30.14;-1000.00;-38.384;-54.080;32;2731.56;72.78;2;2.012
+M;0122;012;01;73045;74.12;0.00;70.47;0.00;-2.81;0.00;30.00;29.90;32.90;20.11;-9999.00;85.20;1200;;;;;;43.30;40.20;27.38;34.38;0.00;2.50;-36.50;0.00;30.14;-1000.00;-51.376;-54.080;32;2730.25;72.78;2;2.012
+M;0122;013;01;73046;59.67;0.00;56.73;0.00;-2.78;0.00;30.00;29.90;32.90;20.11;-9999.00;85.13;1200;;;;;;43.30;40.20;27.38;34.38;0.00;2.50;-36.50;0.00;30.14;-1000.00;-64.376;-54.080;32;2727.79;72.78;2;2.012
+M;0122;014;01;73048;63.72;0.00;60.58;0.00;-2.79;0.00;30.00;29.90;32.80;20.11;-9999.00;84.99;1200;;;;;;43.30;40.20;27.41;34.38;0.00;2.50;-37.00;0.00;30.13;-1000.00;-77.368;-54.080;32;2728.94;72.78;2;2.012
+M;0122;015;01;73049;70.88;0.00;67.39;0.00;-2.78;0.00;30.00;30.00;32.70;20.11;-9999.00;84.92;1200;;;;;;43.20;40.20;27.34;34.38;0.00;2.50;-37.50;0.00;30.13;-1000.00;-90.360;-54.080;32;2727.72;72.78;2;2.012
+M;0122;016;01;73050;58.72;0.00;55.82;0.00;-2.77;0.00;30.00;30.00;32.70;20.11;-9999.00;84.92;1200;;;;;;43.20;40.20;27.34;34.38;0.00;2.50;-37.50;0.00;30.13;-1000.00;-103.368;-54.080;32;2734.70;72.78;2;2.012
+M;0122;017;01;73052;61.83;0.00;58.78;0.00;-2.77;0.00;29.90;30.00;32.70;20.11;-9999.00;84.92;1200;;;;;;43.20;40.10;27.28;34.38;0.00;2.00;-38.50;80.00;30.14;-1000.00;-103.368;-41.096;32;2731.03;72.79;2;2.012
+M;0122;018;01;73053;62.04;0.00;58.98;0.00;-2.78;0.00;30.00;30.00;32.80;20.11;-9999.00;84.95;1199;;;;;;43.40;40.10;27.38;34.38;0.00;2.50;-39.00;80.00;30.14;-1000.00;-90.400;-41.096;32;2728.02;72.78;2;2.012
+M;0122;019;01;73054;72.64;0.00;69.06;0.00;-2.80;0.00;30.00;30.00;32.80;20.11;-9999.00;84.98;1199;;;;;;43.40;40.20;27.38;34.38;0.00;2.50;-39.00;80.00;30.14;-1000.00;-77.408;-41.096;32;2729.72;72.78;2;2.012
+M;0122;020;01;73056;62.19;0.00;59.13;0.00;-2.79;0.00;30.00;30.00;32.80;20.11;-9999.00;85.00;1200;;;;;;43.50;40.10;27.31;34.38;0.00;2.50;-38.00;80.00;30.13;-1000.00;-64.408;-41.088;32;2733.65;72.79;2;2.012
+M;0122;021;01;73057;72.42;0.00;68.85;0.00;-2.81;0.00;30.00;30.00;33.00;20.11;-9999.00;85.08;1199;;;;;;43.50;40.10;27.31;34.38;0.00;2.50;-38.00;80.00;30.13;-1000.00;-51.400;-41.088;32;2724.87;72.77;2;2.012
+M;0122;022;01;73058;62.08;0.00;59.02;0.00;-2.79;0.00;30.00;30.00;33.00;20.11;-9999.00;85.13;1199;;;;;;43.50;40.20;27.31;34.38;0.00;2.50;-38.00;80.00;30.13;-1000.00;-38.408;-41.088;32;2718.64;72.77;2;2.012
+M;0122;023;01;73060;59.28;0.00;56.36;0.00;-2.80;0.00;30.00;30.00;33.10;20.11;-9999.00;85.14;1199;;;;;;43.60;40.20;27.38;34.38;0.00;2.00;-38.00;80.00;30.13;-1000.00;-25.400;-41.088;32;2719.54;72.77;2;2.012
+M;0122;024;01;73061;73.47;0.00;69.85;0.00;-2.81;0.00;30.00;30.00;33.10;20.12;-9999.00;85.21;1199;;;;;;43.60;40.20;27.34;34.38;0.00;2.50;-38.50;80.00;30.13;-1000.00;-12.408;-41.088;32;2720.14;72.78;2;2.012
+M;0122;025;01;73062;65.08;0.00;61.87;0.00;-2.80;0.00;30.00;30.00;33.20;20.12;-9999.00;85.35;1199;;;;;;43.60;40.20;27.34;34.38;0.00;2.00;-39.00;80.00;30.14;-1000.00;-12.408;-28.104;32;2722.59;72.78;2;2.012
+M;0122;026;01;73064;60.28;0.00;57.31;0.00;-2.80;0.00;30.00;30.00;33.20;20.11;-9999.00;85.39;1200;;;;;;43.60;40.20;27.25;34.38;0.00;2.00;-39.00;80.00;30.14;-1000.00;-25.368;-28.104;32;2721.95;72.78;2;2.012
+M;0122;027;01;73065;73.08;0.00;69.48;0.00;-2.81;0.00;30.00;30.00;33.30;20.12;-9999.00;85.43;1200;;;;;;43.60;40.20;27.38;34.38;0.00;2.00;-38.50;80.00;30.14;-1000.00;-38.384;-28.104;32;2718.99;72.78;2;2.012
+M;0122;028;01;73066;62.77;0.00;59.68;0.00;-2.81;0.00;30.00;30.00;33.30;20.12;-9999.00;85.51;1200;;;;;;43.60;40.20;27.38;34.38;0.00;2.00;-38.50;80.00;30.14;-1000.00;-51.376;-28.096;32;2721.11;72.78;2;2.012
+M;0122;029;01;73068;68.84;0.00;65.45;0.00;-2.81;0.00;30.00;30.00;33.30;20.12;-9999.00;85.55;1200;;;;;;43.60;40.10;27.41;34.38;0.00;2.00;-38.00;0.00;30.13;-1000.00;-64.376;-28.096;32;2722.43;72.78;2;2.012
+M;0122;030;01;73069;56.39;0.00;53.61;0.00;-2.77;0.00;30.00;30.00;33.40;20.12;-9999.00;85.61;1200;;;;;;43.50;40.10;27.31;34.38;0.00;2.00;-38.00;0.00;30.13;-1000.00;-77.368;-28.096;32;2725.88;72.78;2;2.012
+M;0122;031;01;73070;67.06;0.00;63.75;0.00;-2.79;0.00;30.00;30.00;33.40;20.12;-9999.00;85.65;1200;;;;;;43.50;40.10;27.31;34.38;0.00;2.00;-38.00;0.00;30.13;-1000.00;-90.360;-28.096;32;2728.13;72.79;2;2.012
+M;0122;032;01;73072;60.20;0.00;57.24;0.00;-2.80;0.00;30.00;30.00;33.40;20.12;-9999.00;85.57;1200;;;;;;43.50;40.20;27.28;34.38;0.00;2.00;-38.50;0.00;30.13;-1000.00;-103.368;-28.096;32;2726.40;72.78;2;2.012
+P;0122;;;73072;;;;;;;30.00;30.00;33.40;20.12;-9999.00;85.57;1200;;;;;;43.50;40.20;27.28;34.38;0.00;2.00;-38.50;0.00;30.13;-1000.00;-103.368;-28.096;32;;;;2.014;1.336;1.071;1.055;1.318;
+P;0122;;;73072;;;;;;;30.00;30.00;33.40;20.12;-9999.00;85.57;1200;;;;;;43.50;40.20;27.28;34.38;0.00;2.00;-38.50;0.00;30.13;-1000.00;-103.368;-28.096;0;;;;2.014;1.336;1.071;1.055;1.318;
+R;0122;;02;73104;212.56;0.00;;;;;30.00;29.90;33.40;20.12;-9999.00;85.58;1199;2747.62;;;;;43.50;40.10;27.34;34.38;0.00;2.00;-36.50;0.00;30.13;-1000.00;-124.864;-69.552;31;2747.62;72.80;2;2.014
+M;0122;001;02;73106;282.16;0.00;270.24;0.00;-2.83;0.00;30.00;29.90;33.40;20.12;-9999.00;85.48;1199;#;;;;;43.50;40.20;27.38;34.38;0.00;2.00;-36.50;0.00;30.14;-1000.00;-103.408;-67.088;33;2734.30;72.79;2;2.014
+M;0122;002;02;73107;269.77;0.00;258.38;0.00;-2.83;0.00;30.00;29.90;33.30;20.12;-9999.00;85.44;1200;;;;;;43.50;40.20;27.38;34.38;0.00;2.00;-36.50;0.00;30.13;-1000.00;-90.408;-67.088;33;2732.39;72.79;2;2.014
+M;0122;003;02;73109;228.72;0.00;219.06;0.00;-2.85;0.00;30.00;29.90;33.20;20.12;-9999.00;85.29;1200;;;;;;43.40;40.20;27.38;34.38;0.00;2.00;-36.50;0.00;30.13;-1000.00;-77.408;-67.088;33;2730.19;72.79;2;2.014
+M;0122;004;02;73110;275.81;0.00;264.16;0.00;-2.82;0.00;30.00;29.90;33.20;20.12;-9999.00;85.23;1200;;;;;;43.40;40.20;27.38;34.38;0.00;2.00;-36.50;0.00;30.13;-1000.00;-64.408;-67.088;33;2728.72;72.79;2;2.014
+M;0122;005;02;73111;238.50;0.00;228.42;0.00;-2.85;0.00;30.00;29.90;33.10;20.12;-9999.00;85.16;1199;;;;;;43.40;40.20;27.38;34.38;0.00;2.00;-36.50;0.00;30.14;-1000.00;-51.400;-67.088;33;2726.21;72.79;2;2.014
+M;0122;006;02;73113;249.84;0.00;239.29;0.00;-2.84;0.00;30.00;29.90;33.00;20.12;-9999.00;85.00;1199;;;;;;43.40;40.20;27.38;34.38;0.00;2.00;-36.50;0.00;30.13;-1000.00;-38.408;-67.088;33;2724.28;72.80;2;2.014
+M;0122;007;02;73114;272.76;0.00;261.24;0.00;-2.83;0.00;30.00;29.90;32.90;20.12;-9999.00;84.96;1199;;;;;;43.40;40.20;27.34;34.38;0.00;2.00;-36.50;0.00;30.13;-1000.00;-25.400;-67.088;33;2723.64;72.79;2;2.014
+M;0122;008;02;73115;273.78;0.00;262.22;0.00;-2.82;0.00;30.00;29.90;32.90;20.12;-9999.00;84.92;1199;;;;;;43.40;40.20;27.34;34.38;0.00;2.00;-36.50;0.00;30.14;-1000.00;-12.408;-67.088;33;2724.14;72.80;2;2.014
+M;0122;009;02;73117;287.57;0.00;275.43;0.00;-2.81;0.00;29.90;30.00;32.80;20.12;-9999.00;84.89;1199;;;;;;43.30;40.20;27.34;34.38;0.00;2.50;-37.50;80.00;30.13;-1000.00;-12.408;-54.088;33;2726.34;72.79;2;2.014
+M;0122;010;02;73118;261.04;0.00;250.02;0.00;-2.83;0.00;29.90;30.00;32.80;20.12;-9999.00;84.88;1199;;;;;;43.30;40.20;27.38;34.38;0.00;2.50;-37.50;80.00;30.14;-1000.00;-25.368;-54.088;33;2722.31;72.79;2;2.014
+M;0122;011;02;73119;234.82;0.00;224.90;0.00;-2.84;0.00;29.90;30.00;32.90;20.12;-9999.00;84.93;1200;;;;;;43.50;40.20;27.38;34.38;0.00;2.50;-37.50;80.00;30.13;-1000.00;-38.384;-54.080;33;2720.84;72.79;2;2.014
+M;0122;012;02;73121;292.98;0.00;280.61;0.00;-2.81;0.00;29.90;30.00;33.00;20.11;-9999.00;84.99;1200;;;;;;43.60;40.20;27.38;34.38;0.00;2.50;-38.50;80.00;30.13;-1000.00;-51.376;-54.080;33;2721.74;72.79;2;2.014
+M;0122;013;02;73122;235.61;0.00;225.66;0.00;-2.84;0.00;29.90;30.00;33.00;20.11;-9999.00;85.05;1200;;;;;;43.60;40.20;27.34;34.38;0.00;2.50;-38.50;80.00;30.13;-1000.00;-64.376;-54.080;33;2722.74;72.79;2;2.014
+M;0122;014;02;73123;251.93;0.00;241.29;0.00;-2.83;0.00;30.00;30.00;33.10;20.11;-9999.00;85.11;1200;;;;;;43.60;40.20;27.31;34.38;0.00;2.50;-38.50;80.00;30.13;-1000.00;-77.368;-54.080;33;2723.24;72.79;2;2.014
+M;0122;015;02;73125;279.13;0.00;267.35;0.00;-2.82;0.00;29.90;30.00;33.20;20.11;-9999.00;85.15;1200;;;;;;43.70;40.20;27.31;34.38;0.00;2.50;-39.00;80.00;30.13;-1000.00;-90.360;-54.080;33;2722.76;72.79;2;2.014
+M;0122;016;02;73126;232.30;0.00;222.49;0.00;-2.84;0.00;30.00;30.00;33.30;20.11;-9999.00;85.24;1199;;;;;;43.70;40.20;27.44;34.38;0.00;2.50;-39.50;80.00;30.13;-1000.00;-103.368;-54.080;33;2723.35;72.79;2;2.014
+M;0122;017;02;73127;243.49;0.00;233.21;0.00;-2.83;0.00;30.00;30.00;33.30;20.11;-9999.00;85.31;1200;;;;;;43.70;40.20;27.38;34.38;0.00;2.50;-39.50;80.00;30.13;-1000.00;-103.368;-41.096;33;2722.99;72.80;2;2.014
+M;0122;018;02;73129;245.82;0.00;235.44;0.00;-2.83;0.00;29.90;30.00;33.30;20.11;-9999.00;85.37;1200;;;;;;43.70;40.20;27.38;34.38;0.00;2.50;-40.00;80.00;30.13;-1000.00;-90.408;-41.096;33;2720.47;72.80;2;2.014
+M;0122;019;02;73130;286.70;0.00;274.59;0.00;-2.81;0.00;30.00;30.00;33.40;20.12;-9999.00;85.44;1200;;;;;;43.80;40.20;27.34;34.38;0.00;2.50;-39.50;80.00;30.13;-1000.00;-77.408;-41.096;33;2724.68;72.80;2;2.014
+M;0122;020;02;73131;247.16;0.00;236.73;0.00;-2.83;0.00;30.00;30.00;33.40;20.12;-9999.00;85.49;1199;;;;;;43.80;40.20;27.41;34.38;0.00;2.50;-39.50;80.00;30.13;-1000.00;-64.408;-41.096;33;2725.10;72.80;2;2.014
+M;0122;021;02;73133;286.09;0.00;274.01;0.00;-2.81;0.00;29.90;30.00;33.50;20.12;-9999.00;85.54;1199;;;;;;43.80;40.20;27.41;34.38;0.00;2.00;-39.50;0.00;30.13;-1000.00;-51.400;-41.096;33;2722.52;72.79;2;2.014
+M;0122;022;02;73134;245.01;0.00;234.66;0.00;-2.83;0.00;29.90;30.00;33.50;20.12;-9999.00;85.60;1199;;;;;;43.60;40.10;27.44;34.38;0.00;2.50;-39.50;0.00;30.13;-1000.00;-38.408;-41.096;33;2719.96;72.79;2;2.014
+M;0122;023;02;73135;233.55;0.00;223.69;0.00;-2.84;0.00;29.90;30.00;33.50;20.12;-9999.00;85.64;1199;;;;;;43.60;40.10;27.38;34.38;0.00;2.50;-39.50;0.00;30.13;-1000.00;-25.400;-41.096;33;2720.24;72.80;2;2.014
+M;0122;024;02;73137;289.67;0.00;277.43;0.00;-2.80;0.00;29.90;30.00;33.50;20.12;-9999.00;85.56;1199;;;;;;43.60;40.10;27.38;34.38;0.00;3.00;-39.50;0.00;30.13;-1000.00;-12.408;-41.096;33;2717.96;72.80;2;2.014
+M;0122;025;02;73138;256.71;0.00;245.86;0.00;-2.82;0.00;29.90;30.00;33.40;20.12;-9999.00;85.50;1199;;;;;;43.50;40.20;27.38;34.38;0.00;2.50;-39.50;0.00;30.13;-1000.00;-12.408;-28.104;33;2721.21;72.80;2;2.014
+M;0122;026;02;73139;237.93;0.00;227.88;0.00;-2.83;0.00;29.90;30.00;33.40;20.12;-9999.00;85.44;1199;;;;;;43.50;40.20;27.41;34.38;0.00;2.50;-39.50;0.00;30.13;-1000.00;-25.368;-28.104;33;2721.62;72.80;2;2.014
+M;0122;027;02;73141;288.52;0.00;276.33;0.00;-2.80;0.00;29.90;30.00;33.30;20.12;-9999.00;85.30;1199;;;;;;43.50;40.20;27.41;34.38;0.00;2.50;-38.50;0.00;30.13;-1000.00;-38.376;-28.104;33;2722.65;72.80;2;2.014
+M;0122;028;02;73142;247.40;0.00;236.95;0.00;-2.82;0.00;29.90;30.00;33.20;20.12;-9999.00;85.24;1200;;;;;;43.50;40.20;27.34;34.38;0.00;2.50;-38.50;0.00;30.13;-1000.00;-51.376;-28.104;33;2722.30;72.80;2;2.014
+M;0122;029;02;73143;272.31;0.00;260.81;0.00;-2.81;0.00;29.90;30.00;33.20;20.12;-9999.00;85.16;1200;;;;;;43.50;40.20;27.38;34.38;0.00;2.50;-38.50;0.00;30.13;-1000.00;-64.368;-28.104;33;2722.30;72.80;2;2.014
+M;0122;030;02;73145;223.77;0.00;214.32;0.00;-2.84;0.00;29.90;30.00;33.10;20.12;-9999.00;85.03;1200;;;;;;43.40;40.20;27.38;34.38;0.00;2.50;-39.00;0.00;30.14;-1000.00;-77.368;-28.104;33;2722.44;72.79;2;2.014
+M;0122;031;02;73146;264.59;0.00;253.42;0.00;-2.81;0.00;29.90;30.00;33.00;20.12;-9999.00;84.98;1200;;;;;;43.40;40.20;27.41;34.38;0.00;3.00;-38.00;0.00;30.13;-1000.00;-90.360;-28.104;33;2723.63;72.80;2;2.014
+M;0122;032;02;73147;237.32;0.00;227.29;0.00;-2.82;0.00;29.90;30.00;33.00;20.12;-9999.00;84.94;1199;;;;;;43.40;40.20;27.34;34.38;0.00;3.00;-38.00;0.00;30.13;-1000.00;-103.368;-28.104;33;2726.09;72.80;2;2.014
+P;0122;;;73147;;;;;;;29.90;30.00;33.00;20.12;-9999.00;84.94;1199;;;;;;43.40;40.20;27.34;34.38;0.00;3.00;-38.00;0.00;30.13;-1000.00;-103.368;-28.104;33;;;;2.014;1.332;1.071;1.055;1.312;
+P;0122;;;73149;;;;;;;29.90;30.00;32.90;20.12;-9999.00;84.89;1199;;;;;;43.40;40.20;27.34;34.38;0.00;2.50;-39.00;0.00;30.14;-1000.00;-103.368;-28.104;2;;;;2.014;1.333;1.071;1.055;1.313;
+M;0122;001;03;73170;76.49;0.00;0.00;0.00;31.79;6.55;30.00;29.90;33.60;20.11;-9999.00;85.62;1199;;;;;;43.70;40.20;27.28;34.38;0.00;2.00;-37.00;0.00;30.13;-1000.00;-99.408;-70.056;22;3473.31;72.12;4;2.014
+M;0122;002;03;73171;85.59;0.00;0.00;0.00;31.73;6.56;30.00;29.90;33.60;20.11;-9999.00;85.56;1199;;;;;;43.70;40.10;27.28;34.38;0.00;2.00;-37.00;0.00;30.13;-1000.00;-86.400;-70.056;22;3470.94;72.11;4;2.014
+M;0122;003;03;73173;86.66;0.00;0.00;0.00;31.81;6.55;30.00;29.90;33.50;20.11;-9999.00;85.42;1199;;;;;;43.60;40.10;27.41;34.38;0.00;2.50;-36.50;0.00;30.13;-1000.00;-73.408;-70.056;22;3469.59;72.12;4;2.014
+M;0122;004;03;73174;82.01;0.00;0.00;0.00;31.79;6.55;30.00;29.90;33.40;20.11;-9999.00;85.36;1199;;;;;;43.60;40.20;27.41;34.38;0.00;2.50;-36.50;0.00;30.13;-1000.00;-60.400;-70.056;22;3468.32;72.12;4;2.014
+M;0122;005;03;73175;87.79;0.00;0.00;0.00;31.80;6.55;30.00;29.90;33.30;20.11;-9999.00;85.28;1199;;;;;;43.60;40.10;27.34;34.38;0.00;2.50;-37.00;0.00;30.13;-1000.00;-47.400;-70.056;22;3468.06;72.11;4;2.014
+M;0122;006;03;73177;85.78;0.00;0.00;0.00;33.68;6.46;30.00;29.90;33.30;20.11;-9999.00;85.15;1199;;;;;;43.60;40.10;27.38;34.38;0.00;2.50;-37.00;0.00;30.14;-1000.00;-34.408;-70.056;22;3466.73;72.12;4;2.014
+M;0122;007;03;73178;93.75;0.00;0.00;0.00;31.76;6.56;30.00;29.90;33.10;20.11;-9999.00;85.07;1199;;;;;;43.50;40.10;27.38;34.38;0.00;2.00;-37.50;0.00;30.13;-1000.00;-21.400;-70.056;22;3465.72;72.11;4;2.014
+M;0122;008;03;73179;74.34;0.00;0.00;0.00;32.03;6.54;29.90;30.00;33.00;20.11;-9999.00;85.00;1199;;;;;;43.50;40.10;27.34;34.38;0.00;2.50;-37.50;0.00;30.13;-1000.00;-8.408;-70.056;22;3462.80;72.12;4;2.014
+M;0122;009;03;73181;86.39;0.00;0.00;0.00;31.52;6.57;29.90;30.00;33.00;20.11;-9999.00;84.90;1199;;;;;;43.50;40.10;27.47;34.38;0.00;2.50;-37.50;0.00;30.13;-1000.00;-8.408;-57.088;22;3462.93;72.12;4;2.014
+M;0122;010;03;73182;81.42;0.00;0.00;0.00;31.77;6.56;29.90;30.00;33.00;20.11;-9999.00;84.88;1200;;;;;;43.50;40.20;27.47;34.38;0.00;2.50;-38.00;0.00;30.13;-1000.00;-21.368;-57.088;22;3461.82;72.12;4;2.014
+M;0122;011;03;73183;83.29;0.00;0.00;0.00;31.89;6.55;29.90;30.00;33.00;20.11;-9999.00;84.89;1200;;;;;;43.50;40.20;27.34;34.38;0.00;2.50;-38.50;80.00;30.13;-1000.00;-34.376;-57.088;22;3462.27;72.13;4;2.014
+M;0122;012;03;73185;82.95;0.00;0.00;0.00;32.13;6.54;29.90;30.00;33.00;20.11;-9999.00;84.90;1200;;;;;;43.50;40.20;27.31;34.38;0.00;2.50;-38.50;80.00;30.14;-1000.00;-47.376;-57.088;22;3464.25;72.13;4;2.014
+M;0122;013;03;73186;77.29;0.00;0.00;0.00;31.65;6.56;29.90;30.00;33.10;20.11;-9999.00;84.98;1200;;;;;;43.70;40.20;27.31;34.38;0.00;2.50;-38.50;80.00;30.13;-1000.00;-60.376;-57.088;22;3463.76;72.13;4;2.014
+M;0122;014;03;73188;86.86;0.00;0.00;0.00;31.50;6.57;29.90;30.00;33.20;20.11;-9999.00;85.03;1200;;;;;;43.70;40.20;27.31;34.38;0.00;2.50;-39.50;80.00;30.13;-1000.00;-73.376;-57.088;22;3464.30;72.13;4;2.014
+M;0122;015;03;73189;82.19;0.00;0.00;0.00;31.55;6.57;29.90;30.00;33.20;20.11;-9999.00;85.09;1200;;;;;;43.70;40.20;27.41;34.38;0.00;2.50;-39.50;80.00;30.14;-1000.00;-86.360;-57.080;22;3464.23;72.12;4;2.014
+M;0122;016;03;73190;76.15;0.00;0.00;0.00;31.05;6.59;29.90;30.00;33.30;20.11;-9999.00;85.21;1200;;;;;;43.80;40.10;27.41;34.38;0.00;2.50;-39.50;80.00;30.13;-1000.00;-99.368;-57.080;22;3463.04;72.12;4;2.014
+M;0122;017;03;73192;74.36;0.00;0.00;0.00;31.82;6.55;30.00;30.00;33.40;20.11;-9999.00;85.29;1200;;;;;;43.80;40.10;27.38;34.38;0.00;2.50;-39.50;80.00;30.13;-1000.00;-99.368;-44.096;22;3462.82;72.13;4;2.014
+M;0122;018;03;73193;86.88;0.00;0.00;0.00;31.89;6.55;30.00;30.00;33.40;20.11;-9999.00;85.35;1200;;;;;;43.80;40.10;27.34;34.38;0.00;2.50;-39.50;80.00;30.13;-1000.00;-86.400;-44.096;22;3465.40;72.13;4;2.014
+M;0122;019;03;73194;92.94;0.00;0.00;0.00;32.01;6.54;30.00;30.00;33.50;20.11;-9999.00;85.46;1200;;;;;;43.80;40.20;27.34;34.38;0.00;2.50;-39.50;80.00;30.13;-1000.00;-73.408;-44.096;22;3468.16;72.13;4;2.014
+M;0122;020;03;73196;95.18;0.00;0.00;0.00;31.88;6.55;30.00;30.00;33.60;20.11;-9999.00;85.48;1200;;;;;;43.90;40.10;27.38;34.38;0.00;2.00;-40.00;80.00;30.13;-1000.00;-60.408;-44.096;22;3468.21;72.13;4;2.014
+M;0122;021;03;73197;89.48;0.00;0.00;0.00;31.76;6.56;30.00;30.00;33.60;20.11;-9999.00;85.56;1200;;;;;;43.90;40.10;27.38;34.38;0.00;2.50;-39.50;0.00;30.13;-1000.00;-47.400;-44.096;22;3466.47;72.13;4;2.014
+M;0122;022;03;73198;94.06;0.00;0.00;0.00;31.98;6.54;30.00;30.00;33.60;20.11;-9999.00;85.65;1200;;;;;;43.90;40.10;27.38;34.38;0.00;2.50;-39.50;0.00;30.13;-1000.00;-34.408;-44.096;22;3463.42;72.13;4;2.014
+M;0122;023;03;73200;94.15;0.00;0.00;0.00;31.89;6.55;29.90;30.00;33.60;20.11;-9999.00;85.65;1199;;;;;;43.70;40.10;27.34;34.38;0.00;2.50;-40.00;0.00;30.13;-1000.00;-21.408;-44.096;22;3461.78;72.13;4;2.014
+M;0122;024;03;73201;95.85;0.00;0.00;0.00;32.18;6.54;29.90;30.00;33.60;20.11;-9999.00;85.65;1199;;;;;;43.70;40.10;27.28;34.38;0.00;2.50;-40.00;0.00;30.13;-1000.00;-8.408;-44.096;22;3461.97;72.13;4;2.014
+M;0122;025;03;73202;93.04;0.00;0.00;0.00;31.90;6.55;30.00;30.00;33.60;20.11;-9999.00;85.59;1199;;;;;;43.70;40.10;27.28;34.38;0.00;2.50;-40.00;0.00;30.13;-1000.00;-8.408;-31.104;22;3464.64;72.12;4;2.014
+M;0122;026;03;73204;82.97;0.00;0.00;0.00;31.61;6.56;30.00;30.00;33.50;20.11;-9999.00;85.43;1199;;;;;;43.70;40.10;27.41;34.38;0.00;2.50;-39.50;0.00;30.13;-1000.00;-21.376;-31.104;22;3462.08;72.14;4;2.014
+M;0122;027;03;73205;99.42;0.00;0.00;0.00;32.13;6.54;30.00;30.00;33.50;20.11;-9999.00;85.34;1199;;;;;;43.70;40.10;27.34;34.38;0.00;2.50;-39.50;0.00;30.13;-1000.00;-34.376;-31.104;22;3465.24;72.13;4;2.014
+M;0122;028;03;73206;88.90;0.00;0.00;0.00;31.08;6.59;30.00;30.00;33.40;20.11;-9999.00;85.27;1199;;;;;;43.60;40.10;27.34;34.38;0.00;2.50;-39.50;0.00;30.13;-1000.00;-47.376;-31.104;22;3465.58;72.13;4;2.014
+M;0122;029;03;73208;81.76;0.00;0.00;0.00;31.60;6.56;30.00;30.00;33.30;20.11;-9999.00;85.19;1199;;;;;;43.60;40.20;27.31;34.38;0.00;2.50;-38.50;0.00;30.14;-1000.00;-60.376;-31.104;22;3464.30;72.14;4;2.014
+M;0122;030;03;73209;72.80;0.00;0.00;0.00;31.63;6.56;30.00;30.00;33.30;20.11;-9999.00;85.12;1199;;;;;;43.60;40.20;27.44;34.38;0.00;2.50;-38.50;0.00;30.13;-1000.00;-73.376;-31.104;22;3464.96;72.14;4;2.014
+M;0122;031;03;73210;77.71;0.00;0.00;0.00;31.60;6.56;30.00;30.00;33.20;20.11;-9999.00;85.05;1199;;;;;;43.60;40.10;27.44;34.38;0.00;2.00;-39.00;0.00;30.13;-1000.00;-86.360;-31.104;22;3466.93;72.14;4;2.014
+M;0122;032;03;73212;69.93;0.00;0.00;0.00;31.72;6.56;30.00;30.00;33.10;20.11;-9999.00;84.99;1199;;;;;;43.60;40.10;27.34;34.38;0.00;2.50;-38.50;0.00;30.13;-1000.00;-99.368;-31.104;22;3466.84;72.14;4;2.014
+P;0122;;;73212;;;;;;;30.00;30.00;33.10;20.11;-9999.00;84.99;1199;;;;;;43.60;40.10;27.34;34.38;0.00;2.50;-38.50;0.00;30.13;-1000.00;-99.368;-31.104;22;;;;2.013;1.329;1.071;1.054;1.305;
+P;0122;;;73213;;;;;;;30.00;30.00;33.10;20.11;-9999.00;84.89;1199;;;;;;43.60;40.10;27.34;34.38;0.00;2.50;-38.50;0.00;30.13;-1000.00;-99.368;-31.104;1;;;;2.014;1.329;1.071;1.055;1.305;
+M;0122;001;04;73235;44.37;0.00;0.00;0.00;43.39;91.48;30.00;29.90;33.70;20.12;-9999.00;85.61;1200;;;;;;43.80;40.10;27.31;34.38;0.00;2.00;-36.50;0.00;30.13;-1000.00;-100.408;-65.584;22;2213.42;5.76;3;2.014
+M;0122;002;04;73236;48.50;0.00;0.00;0.00;47.69;73.66;30.00;29.90;33.70;20.12;-9999.00;85.59;1200;;;;;;43.80;40.10;27.31;34.38;0.00;2.00;-36.50;0.00;30.13;-1000.00;-87.400;-65.584;22;2212.10;5.70;3;2.014
+M;0122;003;04;73238;49.81;0.00;0.00;0.00;50.91;61.82;30.00;29.90;33.60;20.11;-9999.00;85.51;1200;;;;;;43.70;40.10;27.47;34.38;0.00;2.00;-36.50;0.00;30.13;-1000.00;-74.408;-65.584;22;2210.60;5.78;3;2.014
+M;0122;004;04;73239;50.59;0.00;0.00;0.00;45.83;81.05;30.00;29.90;33.50;20.11;-9999.00;85.46;1200;;;;;;43.70;40.10;27.34;34.38;0.00;2.00;-36.50;0.00;30.13;-1000.00;-61.408;-65.584;22;2210.21;5.68;3;2.014
+M;0122;005;04;73240;46.58;0.00;0.00;0.00;48.95;68.86;30.00;29.90;33.50;20.11;-9999.00;85.36;1200;;;;;;43.70;40.10;27.34;34.31;0.00;2.00;-36.50;0.00;30.13;-1000.00;-48.400;-65.584;22;2209.88;5.68;3;2.014
+M;0122;006;04;73242;45.07;0.00;0.00;0.00;42.86;93.87;30.00;29.90;33.40;20.11;-9999.00;85.23;1199;;;;;;43.70;40.10;27.34;34.31;0.00;2.50;-36.50;0.00;30.13;-1000.00;-35.408;-65.584;22;2207.93;5.75;3;2.014
+M;0122;007;04;73243;43.97;0.00;0.00;0.00;40.28;106.23;30.00;29.90;33.30;20.11;-9999.00;85.18;1199;;;;;;43.70;40.10;27.34;34.38;0.00;2.50;-37.00;0.00;30.13;-1000.00;-22.400;-65.584;22;2206.47;5.71;3;2.014
+M;0122;008;04;73245;53.65;0.00;0.00;0.00;44.23;87.77;30.00;29.90;33.30;20.11;-9999.00;85.10;1199;;;;;;43.70;40.10;27.34;34.38;0.00;2.50;-37.00;0.00;30.13;-1000.00;-9.408;-65.584;22;2205.28;5.70;3;2.014
+M;0122;009;04;73246;48.00;0.00;0.00;0.00;47.45;74.58;30.00;30.00;33.20;20.11;-9999.00;84.95;1199;;;;;;43.60;40.10;27.38;34.38;0.00;2.00;-37.00;0.00;30.13;-1000.00;-9.408;-52.576;22;2205.30;5.69;3;2.014
+M;0122;010;04;73247;44.94;0.00;0.00;0.00;44.82;85.23;30.00;30.00;33.10;20.11;-9999.00;84.92;1200;;;;;;43.60;40.10;27.34;34.38;0.00;2.00;-38.00;0.00;30.13;-1000.00;-22.376;-52.576;22;2204.63;5.74;3;2.014
+M;0122;011;04;73249;39.66;0.00;0.00;0.00;40.99;102.71;30.00;30.00;33.00;20.11;-9999.00;84.87;1200;;;;;;43.60;40.10;27.34;34.38;0.00;2.00;-38.00;80.00;30.13;-1000.00;-35.384;-52.576;22;2204.85;5.75;3;2.014
+M;0122;012;04;73250;52.09;0.00;0.00;0.00;45.02;84.40;30.00;30.00;33.00;20.11;-9999.00;84.85;1200;;;;;;43.60;40.10;27.34;34.38;0.00;2.00;-38.00;80.00;30.13;-1000.00;-48.376;-52.576;22;2205.77;5.73;3;2.014
+M;0122;013;04;73251;40.08;0.00;0.00;0.00;35.70;131.78;30.00;30.00;33.10;20.12;-9999.00;84.89;1200;;;;;;43.70;40.10;27.31;34.38;0.00;2.50;-38.50;80.00;30.13;-1000.00;-61.376;-52.576;22;2205.40;5.75;3;2.014
+M;0122;014;04;73253;64.64;0.00;0.00;0.00;32.72;151.73;30.00;30.00;33.10;20.11;-9999.00;84.90;1200;;;;;;43.70;40.10;27.31;34.38;0.00;2.50;-38.50;80.00;30.13;-1000.00;-74.376;-52.576;22;2205.72;5.70;3;2.014
+M;0122;015;04;73254;49.34;0.00;0.00;0.00;45.75;81.36;30.00;30.00;33.20;20.11;-9999.00;84.94;1200;;;;;;43.80;40.10;27.34;34.38;0.00;2.00;-39.00;80.00;30.14;-1000.00;-87.368;-52.576;22;2205.77;5.72;3;2.014
+M;0122;016;04;73255;47.56;0.00;0.00;0.00;43.90;89.21;30.00;30.00;33.30;20.11;-9999.00;85.07;1200;;;;;;43.90;40.10;27.31;34.38;0.00;2.00;-39.50;80.00;30.13;-1000.00;-100.368;-52.576;22;2205.88;5.76;3;2.014
+M;0122;017;04;73257;45.70;0.00;0.00;0.00;40.35;105.89;30.00;30.00;33.30;20.11;-9999.00;85.16;1200;;;;;;43.90;40.10;27.31;34.38;0.00;2.00;-39.50;80.00;30.14;-1000.00;-100.368;-39.600;22;2205.86;5.71;3;2.014
+M;0122;018;04;73258;48.57;0.00;0.00;0.00;45.97;80.46;30.00;30.00;33.40;20.11;-9999.00;85.19;1200;;;;;;43.90;40.10;27.38;34.38;0.00;2.00;-40.00;80.00;30.13;-1000.00;-87.400;-39.600;22;2205.87;5.69;3;2.014
+M;0122;019;04;73259;50.49;0.00;0.00;0.00;48.07;72.25;29.90;30.00;33.50;20.11;-9999.00;85.33;1200;;;;;;43.90;40.10;27.38;34.38;0.00;2.50;-40.00;80.00;30.13;-1000.00;-74.408;-39.600;22;2207.54;5.80;3;2.014
+M;0122;020;04;73261;62.53;0.00;0.00;0.00;40.96;102.96;29.90;30.00;33.50;20.11;-9999.00;85.38;1200;;;;;;43.90;40.10;27.38;34.38;0.00;2.50;-40.00;80.00;30.13;-1000.00;-61.408;-39.600;22;2207.53;5.79;3;2.014
+M;0122;021;04;73262;52.68;0.00;0.00;0.00;47.47;74.51;30.00;30.00;33.60;20.12;-9999.00;85.42;1199;;;;;;44.00;40.10;27.34;34.38;0.00;2.50;-39.50;80.00;30.13;-1000.00;-48.400;-39.600;22;2206.32;5.76;3;2.014
+M;0122;022;04;73263;41.43;0.00;0.00;0.00;44.50;86.60;30.00;30.00;33.60;20.11;-9999.00;85.50;1199;;;;;;44.00;40.10;27.34;34.38;0.00;2.50;-39.50;80.00;30.13;-1000.00;-35.408;-39.600;22;2204.41;5.73;3;2.014
+M;0122;023;04;73265;42.92;0.00;0.00;0.00;46.43;78.59;30.00;30.00;33.70;20.12;-9999.00;85.57;1199;;;;;;44.00;40.10;27.34;34.38;0.00;2.50;-39.50;80.00;30.13;-1000.00;-22.400;-39.600;22;2202.07;5.68;3;2.014
+M;0122;024;04;73266;46.66;0.00;0.00;0.00;48.91;69.01;30.00;30.00;33.70;20.12;-9999.00;85.62;1199;;;;;;44.00;40.10;27.44;34.38;0.00;2.50;-39.50;0.00;30.14;-1000.00;-9.408;-39.600;22;2202.07;5.80;3;2.014
+M;0122;025;04;73267;59.44;0.00;0.00;0.00;45.24;83.46;30.00;30.00;33.70;20.12;-9999.00;85.63;1199;;;;;;43.90;40.10;27.25;34.38;0.00;2.00;-40.00;0.00;30.13;-1000.00;-9.408;-26.600;22;2202.85;5.73;3;2.014
+M;0122;026;04;73269;46.01;0.00;0.00;0.00;42.77;94.38;29.90;30.00;33.70;20.12;-9999.00;85.58;1199;;;;;;43.80;40.10;27.25;34.38;0.00;2.50;-39.50;0.00;30.14;-1000.00;-22.368;-26.592;22;2202.92;5.73;3;2.014
+M;0122;027;04;73270;54.19;0.00;0.00;0.00;50.38;63.75;29.90;30.00;33.70;20.12;-9999.00;85.54;1199;;;;;;43.80;40.10;27.31;34.38;0.00;2.50;-39.50;0.00;30.13;-1000.00;-35.384;-26.592;22;2204.28;5.74;3;2.014
+M;0122;028;04;73271;65.51;0.00;0.00;0.00;29.62;176.20;30.00;30.00;33.60;20.11;-9999.00;85.49;1199;;;;;;43.80;40.10;27.38;34.38;0.00;2.50;-39.00;0.00;30.13;-1000.00;-48.376;-26.592;22;2204.95;5.72;3;2.014
+M;0122;029;04;73273;45.87;0.00;0.00;0.00;35.41;133.59;30.00;30.00;33.50;20.11;-9999.00;85.41;1199;;;;;;43.80;40.10;27.38;34.38;0.00;2.00;-39.00;0.00;30.13;-1000.00;-61.376;-26.592;22;2204.53;5.71;3;2.014
+M;0122;030;04;73274;44.46;0.00;0.00;0.00;37.33;122.08;30.00;30.00;33.50;20.11;-9999.00;85.28;1200;;;;;;43.80;40.10;27.28;34.38;0.00;2.00;-39.00;0.00;30.13;-1000.00;-74.368;-26.592;22;2206.47;5.70;3;2.014
+M;0122;031;04;73275;46.88;0.00;0.00;0.00;35.97;130.12;30.00;30.00;33.40;20.11;-9999.00;85.19;1199;;;;;;43.70;40.10;27.34;34.38;0.00;2.00;-38.50;0.00;30.14;-1000.00;-87.368;-26.592;22;2207.17;5.74;3;2.014
+M;0122;032;04;73277;49.08;0.00;0.00;0.00;42.70;94.57;30.00;30.00;33.30;20.11;-9999.00;85.13;1199;;;;;;43.70;40.10;27.34;34.38;0.00;2.00;-39.00;0.00;30.13;-1000.00;-100.368;-26.592;22;2206.85;5.73;3;2.014
+P;0122;;;73277;;;;;;;30.00;30.00;33.30;20.11;-9999.00;85.13;1199;;;;;;43.70;40.10;27.34;34.38;0.00;2.00;-39.00;0.00;30.13;-1000.00;-100.368;-26.592;22;;;;2.014;1.328;1.071;1.055;1.304;
+P;0122;;;73279;;;;;;;30.00;30.00;33.10;20.11;-9999.00;85.02;1199;;;;;;43.70;40.10;27.34;34.38;0.00;2.00;-39.00;0.00;30.13;-1000.00;-100.368;-26.592;2;;;;2.013;1.328;1.071;1.055;1.303;
+R;0122;;05;73292;-9999.00;0.00;;;;;30.00;29.90;33.50;20.11;-9999.00;85.19;1200;LED;;;;;44.00;40.10;27.31;34.38;0.00;2.00;-37.00;80.00;30.13;-1000.00;-124.856;-69.552;11;8192.00;0.00;0;2.013
+M;0122;001;05;73297;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.70;20.12;-9999.00;85.46;1199;;;;;;44.10;40.10;27.34;34.38;0.00;2.00;-37.00;80.00;30.13;-1000.00;-103.408;-67.096;16;8192.00;0.00;0;2.013
+M;0122;002;05;73301;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.80;20.12;-9999.00;85.61;1199;;;;;;43.90;40.10;27.34;34.38;0.00;2.00;-36.50;0.00;30.13;-1000.00;-90.400;-67.096;16;8192.00;0.00;0;2.013
+M;0122;003;05;73306;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.60;20.12;-9999.00;85.34;1199;;;;;;43.80;40.10;27.41;34.38;0.00;2.50;-36.50;0.00;30.13;-1000.00;-77.408;-67.096;16;8192.00;0.00;0;2.013
+M;0122;004;05;73310;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.30;20.12;-9999.00;85.10;1199;;;;;;43.70;40.10;27.34;34.38;0.00;2.00;-38.00;0.00;30.13;-1000.00;-64.400;-67.096;16;8192.00;0.00;0;2.013
+M;0122;005;05;73315;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.10;20.12;-9999.00;84.83;1199;;;;;;43.70;40.20;27.44;34.38;0.00;2.50;-39.50;0.00;30.13;-1000.00;-51.400;-67.096;16;8192.00;0.00;0;2.013
+M;0122;006;05;73319;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.20;20.12;-9999.00;84.90;1200;;;;;;43.80;40.10;27.34;34.38;0.00;2.50;-39.50;80.00;30.13;-1000.00;-38.408;-67.096;16;8192.00;0.00;0;2.013
+M;0122;007;05;73324;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.40;20.12;-9999.00;85.11;1200;;;;;;44.00;40.20;27.31;34.38;0.00;2.50;-40.00;80.00;30.13;-1000.00;-25.400;-67.096;16;8192.00;0.00;0;2.013
+M;0122;008;05;73328;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.70;20.12;-9999.00;85.36;1200;;;;;;44.10;40.20;27.41;34.38;0.00;2.00;-40.00;80.00;30.13;-1000.00;-12.408;-67.096;16;8192.00;0.00;0;2.013
+M;0122;009;05;73332;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.80;20.12;-9999.00;85.57;1199;;;;;;44.00;40.10;27.34;34.38;0.00;2.00;-40.00;0.00;30.13;-1000.00;-12.408;-54.088;16;8192.00;0.00;0;2.013
+M;0122;010;05;73337;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.70;20.12;-9999.00;85.50;1200;;;;;;43.90;40.10;27.41;34.38;0.00;2.50;-40.00;0.00;30.13;-1000.00;-25.368;-54.088;16;8192.00;0.00;0;2.013
+M;0122;011;05;73341;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.50;20.12;-9999.00;85.24;1199;;;;;;43.80;40.20;27.31;34.38;0.00;2.00;-40.50;0.00;30.13;-1000.00;-38.384;-54.088;16;8192.00;0.00;0;2.013
+M;0122;012;05;73345;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.30;20.12;-9999.00;84.97;1199;;;;;;43.80;40.20;27.38;34.38;0.00;2.00;-40.50;0.00;30.13;-1000.00;-51.376;-54.080;16;8192.00;0.00;0;2.013
+M;0122;013;05;73350;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.20;20.12;-9999.00;84.82;1199;;;;;;43.70;40.10;27.31;34.38;0.00;2.50;-41.00;80.00;30.13;-1000.00;-64.376;-54.080;16;8192.00;0.00;0;2.013
+M;0122;014;05;73354;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;30.00;33.40;20.12;-9999.00;85.08;1200;;;;;;44.00;40.20;27.38;34.38;0.00;2.50;-41.00;80.00;30.13;-1000.00;-77.368;-54.080;16;8192.00;0.00;0;2.013
+M;0122;015;05;73359;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.60;20.12;-9999.00;85.28;1200;;;;;;44.10;40.10;27.44;34.38;0.00;2.50;-41.50;80.00;30.13;-1000.00;-90.360;-54.080;16;8192.00;0.00;0;2.013
+M;0122;016;05;73363;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.80;20.12;-9999.00;85.50;1200;;;;;;44.20;40.10;27.38;34.38;0.00;2.50;-41.50;80.00;30.13;-1000.00;-103.368;-54.080;16;8192.00;0.00;0;2.013
+M;0122;017;05;73368;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.80;20.12;-9999.00;85.57;1200;;;;;;44.00;40.20;27.38;34.38;0.00;2.50;-41.00;0.00;30.13;-1000.00;-103.368;-41.096;16;8192.00;0.00;0;2.013
+M;0122;018;05;73372;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.60;20.12;-9999.00;85.33;1199;;;;;;43.90;40.10;27.34;34.38;0.00;2.50;-38.50;0.00;30.13;-1000.00;-90.400;-41.096;16;8192.00;0.00;0;2.013
+M;0122;019;05;73377;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;29.90;33.40;20.12;-9999.00;85.03;1199;;;;;;43.90;40.20;27.34;34.38;0.00;2.50;-37.50;0.00;30.13;-1000.00;-77.408;-41.096;16;8192.00;0.00;0;2.013
+M;0122;020;05;73381;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.20;20.12;-9999.00;84.80;1199;;;;;;43.80;40.20;27.34;34.31;0.00;2.00;-37.50;0.00;30.13;-1000.00;-64.408;-41.096;16;8192.00;0.00;0;2.013
+M;0122;021;05;73385;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.40;20.12;-9999.00;84.97;1199;;;;;;44.10;40.20;27.34;34.38;0.00;2.50;-37.50;80.00;30.13;-1000.00;-51.400;-41.096;16;8192.00;0.00;0;2.013
+M;0122;022;05;73390;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;29.90;33.60;20.12;-9999.00;85.16;1199;;;;;;44.20;40.20;27.31;34.38;0.00;2.50;-38.00;80.00;30.13;-1000.00;-38.408;-41.096;16;8192.00;0.00;0;2.013
+M;0122;023;05;73394;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.70;20.12;-9999.00;85.43;1200;;;;;;44.20;40.20;27.34;34.38;0.00;2.50;-39.00;80.00;30.13;-1000.00;-25.400;-41.096;16;8192.00;0.00;0;2.013
+M;0122;024;05;73399;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;29.90;33.90;20.12;-9999.00;85.60;1200;;;;;;44.20;40.20;27.41;34.38;0.00;2.00;-37.50;0.00;30.13;-1000.00;-12.408;-41.096;16;8192.00;0.00;0;2.013
+M;0122;025;05;73403;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.70;20.12;-9999.00;85.39;1200;;;;;;44.00;40.20;27.31;34.38;0.00;2.50;-37.00;0.00;30.13;-1000.00;-12.408;-28.104;16;8192.00;0.00;0;2.013
+M;0122;026;05;73408;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;29.90;33.40;20.12;-9999.00;85.08;1200;;;;;;43.90;40.20;27.34;34.38;0.00;2.00;-37.50;0.00;30.13;-1000.00;-25.368;-28.104;16;8192.00;0.00;0;2.013
+M;0122;027;05;73412;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.20;20.12;-9999.00;84.76;1199;;;;;;43.90;40.20;27.31;34.38;0.00;2.00;-37.50;0.00;30.13;-1000.00;-38.384;-28.104;16;8192.00;0.00;0;2.013
+M;0122;028;05;73417;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.30;20.12;-9999.00;84.88;1198;;;;;;44.00;40.20;27.34;34.38;0.00;2.50;-37.50;80.00;30.13;-1000.00;-51.376;-28.104;16;8192.00;0.00;0;2.013
+M;0122;029;05;73421;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.60;20.12;-9999.00;85.10;1198;;;;;;44.20;40.20;27.38;34.31;0.00;2.00;-39.00;80.00;30.13;-1000.00;-64.376;-28.104;16;8192.00;0.00;0;2.013
+M;0122;030;05;73425;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.80;20.12;-9999.00;85.32;1200;;;;;;44.30;40.10;27.31;34.38;0.00;2.50;-39.00;80.00;30.13;-1000.00;-77.368;-28.104;16;8192.00;0.00;0;2.013
+M;0122;031;05;73430;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;34.00;20.12;-9999.00;85.60;1200;;;;;;44.30;40.10;27.34;34.31;0.00;2.50;-39.50;0.00;30.13;-1000.00;-90.360;-28.104;16;8192.00;0.00;0;2.013
+M;0122;032;05;73434;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;30.00;34.00;20.12;-9999.00;85.59;1200;;;;;;44.10;40.10;27.31;34.31;0.00;2.00;-39.50;0.00;30.14;-1000.00;-103.368;-28.104;16;8192.00;0.00;0;2.013
+P;0122;;;73434;;;;;;;29.90;30.00;34.00;20.12;-9999.00;85.59;1200;#;;;;;44.10;40.10;27.31;34.31;0.00;2.00;-39.50;0.00;30.14;-1000.00;-103.368;-28.104;16;;;;2.012;1.321;1.071;1.054;1.324;
+P;0122;;;73434;;;;;;;29.90;30.00;34.00;20.12;-9999.00;85.59;1200;;;;;;44.10;40.10;27.31;34.31;0.00;2.00;-39.50;0.00;30.14;-1000.00;-103.368;-28.104;0;;;;2.012;1.321;1.071;1.054;1.324;
+R;0122;;06;73449;-9999.00;0.00;;;;;29.90;29.90;33.40;20.12;-9999.00;84.95;1200;LED;;;;;44.10;40.10;27.31;34.38;0.00;2.50;-37.50;80.00;30.13;-1000.00;-124.864;-69.552;11;8192.00;0.00;0;2.012
+M;0122;001;06;73454;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;29.90;33.60;20.12;-9999.00;85.16;1199;;;;;;44.30;40.20;27.38;34.38;0.00;2.50;-37.00;80.00;30.13;-1000.00;-103.408;-67.088;16;8192.00;0.00;0;2.012
+M;0122;002;06;73459;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.80;20.11;-9999.00;85.43;1199;;;;;;44.30;40.10;27.38;34.38;0.00;2.50;-37.00;80.00;30.13;-1000.00;-90.400;-67.088;16;8192.00;0.00;0;2.012
+M;0122;003;06;73463;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;34.00;20.12;-9999.00;85.64;1199;;;;;;44.30;40.10;27.31;34.31;0.00;2.00;-37.00;0.00;30.13;-1000.00;-77.408;-67.088;16;8192.00;0.00;0;2.012
+M;0122;004;06;73467;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.90;20.12;-9999.00;85.64;1200;;;;;;44.20;40.10;27.34;34.38;0.00;2.00;-38.00;0.00;30.13;-1000.00;-64.408;-67.088;16;8192.00;0.00;0;2.012
+M;0122;005;06;73472;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.70;20.12;-9999.00;85.41;1200;;;;;;44.10;40.20;27.38;34.38;0.00;2.50;-39.00;0.00;30.13;-1000.00;-51.400;-67.088;16;8192.00;0.00;0;2.012
+M;0122;006;06;73476;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;30.00;33.30;20.11;-9999.00;85.04;1201;;;;;;44.00;40.20;27.34;34.38;0.00;2.50;-39.50;0.00;30.13;-1000.00;-38.408;-67.088;16;8192.00;0.00;0;2.012
+M;0122;007;06;73481;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;30.00;33.20;20.12;-9999.00;84.81;1200;;;;;;44.00;40.10;27.25;34.31;0.00;2.50;-40.00;80.00;30.13;-1000.00;-25.400;-67.088;16;8192.00;0.00;0;2.012
+M;0122;008;06;73485;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.40;20.12;-9999.00;85.00;1200;;;;;;44.20;40.20;27.34;34.38;0.00;2.50;-40.00;80.00;30.13;-1000.00;-12.408;-67.088;16;8192.00;0.00;0;2.012
+M;0122;009;06;73490;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.60;20.12;-9999.00;85.33;1200;;;;;;44.30;40.20;27.34;34.38;0.00;2.00;-40.00;80.00;30.13;-1000.00;-12.408;-54.088;16;8192.00;0.00;0;2.012
+M;0122;010;06;73494;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.80;20.12;-9999.00;85.56;1199;;;;;;44.30;40.20;27.34;34.31;0.00;2.50;-40.00;80.00;30.13;-1000.00;-25.376;-54.080;16;8192.00;0.00;0;2.012
+M;0122;011;06;73498;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.90;20.12;-9999.00;85.69;1200;;;;;;44.20;40.20;27.25;34.38;0.00;2.00;-40.50;0.00;30.13;-1000.00;-38.384;-54.080;16;8192.00;0.00;0;2.012
+M;0122;012;06;73503;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.80;20.12;-9999.00;85.46;1199;;;;;;44.10;40.10;27.38;34.31;0.00;2.50;-40.50;0.00;30.13;-1000.00;-51.376;-54.080;16;8192.00;0.00;0;2.012
+M;0122;013;06;73507;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.50;20.12;-9999.00;85.14;1199;;;;;;44.10;40.20;27.34;34.38;0.00;2.50;-41.00;0.00;30.13;-1000.00;-64.376;-54.080;16;8192.00;0.00;0;2.012
+M;0122;014;06;73512;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;30.00;33.30;20.12;-9999.00;84.84;1199;;;;;;44.00;40.30;27.28;34.38;0.00;2.50;-41.00;0.00;30.13;-1000.00;-77.368;-54.080;16;8192.00;0.00;0;2.012
+M;0122;015;06;73516;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.40;20.12;-9999.00;84.92;1200;;;;;;44.20;40.20;27.31;34.38;0.00;2.00;-41.00;80.00;30.13;-1000.00;-90.360;-54.080;16;8192.00;0.00;0;2.012
+M;0122;016;06;73521;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.60;20.11;-9999.00;85.21;1199;;;;;;44.30;40.20;27.31;34.38;0.00;2.00;-41.50;80.00;30.13;-1000.00;-103.368;-54.080;16;8192.00;0.00;0;2.012
+M;0122;017;06;73525;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.80;20.12;-9999.00;85.41;1200;;;;;;44.40;40.20;27.34;34.38;0.00;2.00;-41.00;80.00;30.13;-1000.00;-103.368;-41.096;16;8192.00;0.00;0;2.012
+M;0122;018;06;73530;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;34.00;20.12;-9999.00;85.64;1199;;;;;;44.40;40.10;27.34;34.38;0.00;2.00;-38.50;0.00;30.13;-1000.00;-90.408;-41.096;16;8192.00;0.00;0;2.012
+M;0122;019;06;73534;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.80;20.12;-9999.00;85.47;1199;;;;;;44.20;40.20;27.38;34.38;0.00;2.00;-37.50;0.00;30.13;-1000.00;-77.408;-41.088;16;8192.00;0.00;0;2.012
+M;0122;020;06;73539;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;29.90;33.60;20.12;-9999.00;85.18;1199;;;;;;44.10;40.20;27.34;34.38;0.00;2.00;-37.50;0.00;30.13;-1000.00;-64.408;-41.088;16;8192.00;0.00;0;2.012
+M;0122;021;06;73543;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;29.90;33.40;20.12;-9999.00;84.86;1199;;;;;;44.10;40.20;27.38;34.38;0.00;2.50;-37.50;0.00;30.13;-1000.00;-51.400;-41.088;16;8192.00;0.00;0;2.012
+M;0122;022;06;73548;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;30.00;33.40;20.12;-9999.00;84.84;1200;;;;;;44.20;40.20;27.38;34.38;0.00;2.50;-38.50;80.00;30.13;-1000.00;-38.408;-41.088;16;8192.00;0.00;0;2.012
+M;0122;023;06;73552;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.60;20.12;-9999.00;85.03;1200;;;;;;44.30;40.20;27.31;34.38;0.00;2.50;-40.00;80.00;30.13;-1000.00;-25.400;-41.088;16;8192.00;0.00;0;2.012
+M;0122;024;06;73556;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.80;20.12;-9999.00;85.32;1200;;;;;;44.40;40.10;27.38;34.38;0.00;2.50;-39.00;80.00;30.13;-1000.00;-12.408;-41.088;16;8192.00;0.00;0;2.012
+M;0122;025;06;73561;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.90;20.12;-9999.00;85.50;1199;;;;;;44.40;40.10;27.38;34.38;0.00;2.50;-37.50;77.00;30.14;-1000.00;-12.408;-28.104;16;8192.00;0.00;0;2.012
+M;0122;026;06;73565;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;34.00;20.12;-9999.00;85.62;1199;;;;;;44.30;40.10;27.41;34.38;0.00;2.50;-37.50;0.00;30.13;-1000.00;-25.368;-28.104;16;8192.00;0.00;0;2.012
+M;0122;027;06;73569;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;29.90;33.80;20.12;-9999.00;85.36;1199;;;;;;44.20;40.20;27.34;34.38;0.00;2.50;-37.50;0.00;30.13;-1000.00;-38.384;-28.104;16;8192.00;0.00;0;2.012
+M;0122;028;06;73574;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;29.90;33.40;20.13;-9999.00;85.07;1199;;;;;;44.10;40.20;27.31;34.38;0.00;2.50;-37.50;0.00;30.13;-1000.00;-51.376;-28.104;16;8192.00;0.00;0;2.012
+M;0122;029;06;73578;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;29.90;33.30;20.13;-9999.00;84.83;1200;;;;;;44.10;40.20;27.34;34.38;0.00;2.50;-38.00;0.00;30.13;-1000.00;-64.376;-28.104;16;8192.00;0.00;0;2.012
+M;0122;030;06;73583;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;29.90;29.90;33.40;20.13;-9999.00;84.94;1200;;;;;;44.30;40.20;27.38;34.38;0.00;2.50;-38.50;80.00;30.13;-1000.00;-77.368;-28.104;16;8192.00;0.00;0;2.012
+M;0122;031;06;73587;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;30.00;33.70;20.13;-9999.00;85.20;1200;;;;;;44.50;40.20;27.31;34.38;0.00;2.50;-38.50;80.00;30.13;-1000.00;-90.360;-28.104;16;8192.00;0.00;0;2.012
+M;0122;032;06;73592;-9999.00;0.00;REFOVERLD;REFOVERLD;-9999.00;-9999.00;30.00;29.90;33.80;20.12;-9999.00;85.46;1199;;;;;;44.60;40.10;27.38;34.31;0.00;2.00;-39.00;80.00;30.14;-1000.00;-103.368;-28.104;16;8192.00;0.00;0;2.012
+P;0122;;;73592;;;;;;;30.00;29.90;33.80;20.12;-9999.00;85.46;1199;#;;;;;44.60;40.10;27.38;34.31;0.00;2.00;-39.00;80.00;30.14;-1000.00;-103.368;-28.104;16;;;;2.013;1.321;1.071;1.055;1.316;
+=====end_process=====
+[end_date_time] 2022-06-23, 06:46:20

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -497,8 +497,8 @@ class TestBLProParsing:
         assert "BS3" in bldata
         assert "pH" in bldata
         assert "DO" in bldata
-        assert "Riboflavine5" in bldata
-        assert "Riboflavine9" in bldata
+        assert "Fluorescence5" in bldata
+        assert "Fluorescence9" in bldata
         pass
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -33,7 +33,14 @@ BL1_files_without_calibration_info = [
 not_a_bl_file = pathlib.Path(dir_testfiles, "BL1", "incremental", "C42.tmp")
 
 BL2_files = list(pathlib.Path(dir_testfiles, "BLII").iterdir())
-BLPro_files = list(pathlib.Path(dir_testfiles, "BLPro").iterdir())
+BLPro_files = [
+    fp
+    for fp in pathlib.Path(dir_testfiles, "BLPro").iterdir()
+    if fp.name
+    not in {
+        "issue24.csv",
+    }
+]
 calibration_test_file = pathlib.Path(dir_testfiles, "BLPro", "18-FZJ-Test2--2018-02-07-10-01-11.csv")
 incompatible_file = pathlib.Path(dir_testfiles, "incompatible_files", "BL2-file-saved-with-biolection.csv")
 
@@ -481,6 +488,17 @@ class TestBLProParsing:
             t, y = bldata.get_timeseries(fs, "A01")
             assert len(t) == n
             assert len(y) == n
+        pass
+
+    @pytest.mark.xfail(reason="See https://github.com/JuBiotech/bletl/issues/24")
+    def test_issue24(self):
+        bldata = bletl.parse(dir_testfiles / "BLPro" / "issue24.csv")
+        assert "BS1" in bldata
+        assert "BS3" in bldata
+        assert "pH" in bldata
+        assert "DO" in bldata
+        assert "Riboflavine5" in bldata
+        assert "Riboflavine9" in bldata
         pass
 
 


### PR DESCRIPTION
@BioAutomation I added the CSV file you sent as a test case.
This tests currently fails with a `KeyError: '05'` after warning about dropping 7808 measurements ...`because they have REFOVERLD`.

I marked the test case as `XFAIL` because this PR doesn't implement a fix and I don't have time to do that.

By merging the `XFAIL` test first, others can more easily open PRs for a fix.

I anonymized the CSV by replacing serial number, user names, filterset names and removing all but 3 measurement cycles.