### PR TITLE
Check availability of filtersets (closes #24)

### DIFF
--- a/bletl/parsing/blpro.py
+++ b/bletl/parsing/blpro.py
@@ -410,7 +410,7 @@ def transform_into_filtertimeseries(
         # test if any filterset is not available in measurements due to invalid data #issue24
         if filter_number not in measurements.index.get_level_values("filterset"):
             logger.warn(
-                f'Skipped channel %s with name "%s" because no valid measurements are available.',
+                'Skipped channel %s with name "%s" because no valid measurements are available.',
                 fs.filter_type,
                 fs.filter_name,
             )

--- a/bletl/parsing/blpro.py
+++ b/bletl/parsing/blpro.py
@@ -407,10 +407,12 @@ def transform_into_filtertimeseries(
         key = None
         times = None
         values = None
-        #test if any filterset is not available in measurements due to invalid data #issue24
+        # test if any filterset is not available in measurements due to invalid data #issue24
         if filter_number not in measurements.index.get_level_values("filterset"):
             logger.warn(
-                    f'Skipped channel %s with name "%s" because no valid measurements are available.', fs.filter_type, fs.filter_name
+                f'Skipped channel %s with name "%s" because no valid measurements are available.',
+                fs.filter_type,
+                fs.filter_name,
             )
             continue
         elif fs.filter_type == "Intensity" and ("Biomass" in fs.filter_name or "BS" in fs.filter_name):
@@ -444,7 +446,7 @@ def transform_into_filtertimeseries(
         values.columns.name = "well"
         fts = FilterTimeSeries(times, values)
         yield (key, fts)
-        
+
 
 def fetch_calibration_data(lot_number: int, temp: int):
     """Loads calibration data from calibration file. Also triggers file download.

--- a/bletl/parsing/blpro.py
+++ b/bletl/parsing/blpro.py
@@ -407,38 +407,42 @@ def transform_into_filtertimeseries(
         key = None
         times = None
         values = None
-        if fs.filter_type == "Intensity" and ("Biomass" in fs.filter_name or "BS" in fs.filter_name):
-            key = f"BS{int(fs.gain_1)}"
-            times = measurements.xs(filter_number, level="filterset")["time"].unstack()
-            values = measurements.xs(filter_number, level="filterset")["amp_ref_1"].unstack()
-        elif fs.filter_type in {"pH", "DO"} and not return_uncalibrated_optode_data:
-            key = fs.filter_type
-            times = measurements.xs(filter_number, level="filterset")["time"].unstack()
-            values = measurements.xs(filter_number, level="filterset")["cal"].unstack()
-        elif fs.filter_type in {"pH", "DO"} and return_uncalibrated_optode_data:
-            key = fs.filter_type
-            times = measurements.xs(filter_number, level="filterset")["time"].unstack()
-            values = measurements.xs(filter_number, level="filterset")["phase"].unstack()
-        elif fs.filter_type == "Intensity":
-            key = fs.filter_name
-            times = measurements.xs(filter_number, level="filterset")["time"].unstack()
-            values = measurements.xs(filter_number, level="filterset")["amp_ref_1"].unstack()
-        else:
+        if filter_number in measurements.index.get_level_values("filterset"): #test if any filterset is not available in measurements due to invalid data issue24
+            if fs.filter_type == "Intensity" and ("Biomass" in fs.filter_name or "BS" in fs.filter_name):
+                key = f"BS{int(fs.gain_1)}"
+                times = measurements.xs(filter_number, level="filterset")["time"].unstack()
+                values = measurements.xs(filter_number, level="filterset")["amp_ref_1"].unstack()
+            elif fs.filter_type in {"pH", "DO"} and not return_uncalibrated_optode_data:
+                key = fs.filter_type
+                times = measurements.xs(filter_number, level="filterset")["time"].unstack()
+                values = measurements.xs(filter_number, level="filterset")["cal"].unstack()
+            elif fs.filter_type in {"pH", "DO"} and return_uncalibrated_optode_data:
+                key = fs.filter_type
+                times = measurements.xs(filter_number, level="filterset")["time"].unstack()
+                values = measurements.xs(filter_number, level="filterset")["phase"].unstack()
+            elif fs.filter_type == "Intensity":
+                key = fs.filter_name
+                times = measurements.xs(filter_number, level="filterset")["time"].unstack()
+                values = measurements.xs(filter_number, level="filterset")["amp_ref_1"].unstack()
+            else:
+                logger.warn(
+                    f'Skipped {fs.filter_type} channel with name "{fs.filter_name}" because no processing routine is implemented.'
+                )
+                continue
+
+            # transform into nicely formatted DataFrames for FilterTimeSeries
+            times.columns = [no_to_id[c] for c in times.columns]
+            times = times.reindex(sorted(times.columns), axis=1)
+            times.columns.name = "well"
+            values.columns = [no_to_id[c] for c in values.columns]
+            values = values.reindex(sorted(values.columns), axis=1)
+            values.columns.name = "well"
+            fts = FilterTimeSeries(times, values)
+            yield (key, fts)
+        else:#if filterset is not available like in issue 24 print warning
             logger.warn(
-                f'Skipped {fs.filter_type} channel with name "{fs.filter_name}" because no processing routine is implemented.'
-            )
-            continue
-
-        # transform into nicely formatted DataFrames for FilterTimeSeries
-        times.columns = [no_to_id[c] for c in times.columns]
-        times = times.reindex(sorted(times.columns), axis=1)
-        times.columns.name = "well"
-        values.columns = [no_to_id[c] for c in values.columns]
-        values = values.reindex(sorted(values.columns), axis=1)
-        values.columns.name = "well"
-        fts = FilterTimeSeries(times, values)
-        yield (key, fts)
-
+                    f'Skipped {fs.filter_type} channel with name "{fs.filter_name}" because no valid measurements available.'
+                )
 
 def fetch_calibration_data(lot_number: int, temp: int):
     """Loads calibration data from calibration file. Also triggers file download.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -497,8 +497,8 @@ class TestBLProParsing:
         assert "BS3" in bldata
         assert "pH" in bldata
         assert "DO" in bldata
-        assert "Fluorescence5" in bldata
-        assert "Fluorescence9" in bldata
+        assert "Fluorescence5" not in bldata
+        assert "Fluorescence9" not in bldata
         pass
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -33,14 +33,7 @@ BL1_files_without_calibration_info = [
 not_a_bl_file = pathlib.Path(dir_testfiles, "BL1", "incremental", "C42.tmp")
 
 BL2_files = list(pathlib.Path(dir_testfiles, "BLII").iterdir())
-BLPro_files = [
-    fp
-    for fp in pathlib.Path(dir_testfiles, "BLPro").iterdir()
-    if fp.name
-    not in {
-        "issue24.csv",
-    }
-]
+BLPro_files = list(pathlib.Path(dir_testfiles, "BLPro").iterdir())
 calibration_test_file = pathlib.Path(dir_testfiles, "BLPro", "18-FZJ-Test2--2018-02-07-10-01-11.csv")
 incompatible_file = pathlib.Path(dir_testfiles, "incompatible_files", "BL2-file-saved-with-biolection.csv")
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -490,7 +490,7 @@ class TestBLProParsing:
             assert len(y) == n
         pass
 
-    @pytest.mark.xfail(reason="See https://github.com/JuBiotech/bletl/issues/24")
+    #@pytest.mark.xfail(reason="See https://github.com/JuBiotech/bletl/issues/24")
     def test_issue24(self):
         bldata = bletl.parse(dir_testfiles / "BLPro" / "issue24.csv")
         assert "BS1" in bldata


### PR DESCRIPTION
In context of #issue24 this PR added a line for testing if there is valid data for the filterset available. If as in #issue24 all data is masked, a warning message returns.

In my opinion this works fine, but I had a problem with the pytest:

![grafik](https://user-images.githubusercontent.com/100830453/180383683-5dc4e9b2-90fb-4a98-aaec-693c866d0272.png)

Or is this right, because the test has to fail (fs05 and fs09 not available)?

@michaelosthege could you please check and review it?