### PR TITLE
Avoid deprecated pandas method and bump version

### DIFF
--- a/bletl/__init__.py
+++ b/bletl/__init__.py
@@ -19,4 +19,4 @@ from .types import (
     NoMeasurementData,
 )
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/bletl/types.py
+++ b/bletl/types.py
@@ -83,7 +83,7 @@ class BLData(dict):
             to_add["value"] = pandas.melt(filtertimeseries.value, value_name="value").loc[:, "value"]
             to_add["filterset"] = filterset
             to_add.astype({"value": float})
-            narrow = narrow.append(to_add, sort=False)
+            narrow = pandas.concat([narrow, to_add], sort=False)
 
         return narrow.reset_index()
 


### PR DESCRIPTION
Closes #16 and updates the patch version number.