### PR TITLE
Use alphanumeric well IDs in `.fluidics` DataFrame index

### DIFF
--- a/bletl/__init__.py
+++ b/bletl/__init__.py
@@ -19,4 +19,4 @@ from .types import (
     NoMeasurementData,
 )
 
-__version__ = "1.2.3"
+__version__ = "1.3.0"


### PR DESCRIPTION
So far this implements alphanumeric well IDs for the `.fluidics` DataFrame, but not yet for `.valves` and `.module` because it's not clear how they're counted.


Closes #38