### PR TITLE
Fix all typing errors and run mypy in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,7 @@ repos:
   rev: 22.3.0
   hooks:
     - id: black
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v1.3.0
+  hooks:
+  -   id: mypy

--- a/bletl/core.py
+++ b/bletl/core.py
@@ -8,7 +8,7 @@ import urllib.error
 import urllib.request
 import warnings
 from collections.abc import Iterable
-from typing import Optional, Union
+from typing import Optional, Sequence, Union
 
 import numpy
 import pandas
@@ -92,14 +92,14 @@ def get_parser(filepath: Union[str, pathlib.Path]) -> BLDParser:
 def _parse(
     filepath: str,
     drop_incomplete_cycles: bool,
-    lot_number: int,
-    temp: int,
-    cal_0: float = None,
-    cal_100: float = None,
-    phi_min: float = None,
-    phi_max: float = None,
-    pH_0: float = None,
-    dpH: float = None,
+    lot_number: Optional[int],
+    temp: Optional[int],
+    cal_0: Optional[float] = None,
+    cal_100: Optional[float] = None,
+    phi_min: Optional[float] = None,
+    phi_max: Optional[float] = None,
+    pH_0: Optional[float] = None,
+    dpH: Optional[float] = None,
 ) -> BLData:
     """Parses a raw BioLector CSV file into a BLData object.
 
@@ -138,29 +138,39 @@ def _parse(
         When the file contents do not match with a known BioLector result file format.
     """
     parser = get_parser(filepath)
-    data = parser.parse(filepath, lot_number, temp, cal_0, cal_100, phi_min, phi_max, pH_0, dpH)
+    data = parser.parse(
+        filepath,
+        lot_number=lot_number,
+        temp=temp,
+        cal_0=cal_0,
+        cal_100=cal_100,
+        phi_min=phi_min,
+        phi_max=phi_max,
+        pH_0=pH_0,
+        dpH=dpH,
+    )
 
     if (not data.measurements.empty) and drop_incomplete_cycles:
         index_names, measurements = utils._unindex(data.measurements)
         latest_full_cycle = utils._last_full_cycle(measurements)
         measurements = measurements[measurements.cycle <= latest_full_cycle]
-        data._measurements = utils._reindex(measurements, index_names)
+        data._measurements = utils._reindex(measurements, index_names)  # type: ignore
 
     return data
 
 
 def parse(
-    filepaths,
+    filepaths: Union[str, Sequence[str]],
     *,
     drop_incomplete_cycles: bool = True,
-    lot_number: int = None,
-    temp: int = None,
-    cal_0: float = None,
-    cal_100: float = None,
-    phi_min: float = None,
-    phi_max: float = None,
-    pH_0: float = None,
-    dpH: float = None,
+    lot_number: Optional[int] = None,
+    temp: Optional[int] = None,
+    cal_0: Optional[float] = None,
+    cal_100: Optional[float] = None,
+    phi_min: Optional[float] = None,
+    phi_max: Optional[float] = None,
+    pH_0: Optional[float] = None,
+    dpH: Optional[float] = None,
 ) -> BLData:
     """Parses a raw BioLector CSV file into a BLData object and applies calibration.
 

--- a/bletl/parsing/bl1.py
+++ b/bletl/parsing/bl1.py
@@ -92,12 +92,12 @@ class BioLector1Parser(BLDParser):
     def calibrate_with_parameters(
         self,
         data: BLData,
-        cal_0: float = None,
-        cal_100: float = None,
-        phi_min: float = None,
-        phi_max: float = None,
-        pH_0: float = None,
-        dpH: float = None,
+        cal_0: Optional[float] = None,
+        cal_100: Optional[float] = None,
+        phi_min: Optional[float] = None,
+        phi_max: Optional[float] = None,
+        pH_0: Optional[float] = None,
+        dpH: Optional[float] = None,
     ):
         def process_backscatter(raw_data_df, cycle_ref_df, global_ref):
             """
@@ -182,14 +182,14 @@ class BioLector1Parser(BLDParser):
     def parse(
         self,
         filepath,
-        lot_number: int = None,
-        temp: int = None,
-        cal_0: float = None,
-        cal_100: float = None,
-        phi_min: float = None,
-        phi_max: float = None,
-        pH_0: float = None,
-        dpH: float = None,
+        lot_number: Optional[int] = None,
+        temp: Optional[int] = None,
+        cal_0: Optional[float] = None,
+        cal_100: Optional[float] = None,
+        phi_min: Optional[float] = None,
+        phi_max: Optional[float] = None,
+        pH_0: Optional[float] = None,
+        dpH: Optional[float] = None,
     ):
         headerlines, data = split_header_data(filepath)
 
@@ -476,6 +476,8 @@ def fetch_calibration_data(lot_number: int, temp: int):
         Dictionary containing calibration data.
         Can be readily used in calibration function.
     """
+    assert utils.__spec__ is not None
+    assert utils.__spec__.origin is not None
     module_path = pathlib.Path(utils.__spec__.origin).parents[0]
     calibration_file = pathlib.Path(module_path, "cache", "CalibrationLot.ini")
 

--- a/bletl/parsing/blpro.py
+++ b/bletl/parsing/blpro.py
@@ -3,15 +3,15 @@ import collections
 import datetime
 import io
 import logging
+import os
 import pathlib
 import re
 import warnings
 import xml.etree.ElementTree
+from typing import Optional, Union
 
 import numpy
 import pandas
-
-from bletl.parsing.bl1 import fetch_calibration_data
 
 from .. import utils
 from ..types import (
@@ -28,15 +28,15 @@ logger = logging.getLogger("blpro")
 class BioLectorProParser(BLDParser):
     def parse(
         self,
-        filepath,
-        lot_number: int = None,
-        temp: int = None,
-        cal_0: float = None,
-        cal_100: float = None,
-        phi_min: float = None,
-        phi_max: float = None,
-        pH_0: float = None,
-        dpH: float = None,
+        filepath: Union[str, os.PathLike],
+        lot_number: Optional[int] = None,
+        temp: Optional[int] = None,
+        cal_0: Optional[float] = None,
+        cal_100: Optional[float] = None,
+        phi_min: Optional[float] = None,
+        phi_max: Optional[float] = None,
+        pH_0: Optional[float] = None,
+        dpH: Optional[float] = None,
     ) -> BLData:
         metadata, data = parse_metadata_data(filepath)
 
@@ -54,7 +54,7 @@ class BioLectorProParser(BLDParser):
         bld.valves, bld.module = extract_valves_module(data)
         bld.diagnostics = extract_diagnostics(data)
 
-        if not None in [lot_number, temp]:
+        if lot_number is not None and temp is not None:
             lot_cal_data = fetch_calibration_data(lot_number, temp)
         else:
             lot_cal_data = None
@@ -476,6 +476,8 @@ def fetch_calibration_data(lot_number: int, temp: int):
         Dictionary containing calibration data.
         Can be readily used in calibration function.
     """
+    assert utils.__spec__ is not None
+    assert utils.__spec__.origin is not None
     module_path = pathlib.Path(utils.__spec__.origin).parents[0]
     calibration_file = pathlib.Path(module_path, "cache", "CalibrationLot_II.xml")
 

--- a/bletl/utils.py
+++ b/bletl/utils.py
@@ -3,14 +3,16 @@ import datetime
 import pathlib
 import re
 import urllib
-from typing import Sequence, Tuple, Union
+from typing import Optional, Sequence, Tuple, Union
 
 import pandas
 
 from . import core
 
 
-def __to_typed_cols__(dfin: pandas.DataFrame, ocol_ncol_type: Tuple[str, str, type]) -> pandas.DataFrame:
+def __to_typed_cols__(
+    dfin: pandas.DataFrame, ocol_ncol_type: Sequence[Tuple[Optional[str], str, type]]
+) -> pandas.DataFrame:
     """Can be used to filter & convert data frame columns.
 
     Parameters
@@ -35,7 +37,7 @@ def __to_typed_cols__(dfin: pandas.DataFrame, ocol_ncol_type: Tuple[str, str, ty
     return dfout
 
 
-def _unindex(dataframe: pandas.DataFrame) -> Tuple[Sequence[Union[str, None]], pandas.DataFrame]:
+def _unindex(dataframe: pandas.DataFrame) -> Tuple[Sequence[Optional[str]], pandas.DataFrame]:
     """Resets the index of the DataFrame.
 
     Parameters
@@ -110,10 +112,10 @@ def _concatenate_fragments(
         stack = pandas.concat((stack, fragment))
 
     # re-apply the original indexing scheme
-    return _reindex(stack, index_names)
+    return _reindex(stack, index_names)  # type: ignore
 
 
-def _last_well_in_cycle(measurements: pandas.DataFrame) -> str:
+def _last_well_in_cycle(measurements: pandas.DataFrame) -> Optional[str]:
     """Finds the name of the last well measured in a cycle.
 
     Parameters
@@ -195,6 +197,8 @@ def download_calibration_data() -> bool:
         `True` if calibration data was downloaded successfully, `False` otherwise.
     """
     try:
+        assert core.__spec__ is not None
+        assert core.__spec__.origin is not None
         module_path = pathlib.Path(core.__spec__.origin).parents[0]
 
         url_bl1 = "http://updates.m2p-labs.com/CalibrationLot.ini"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,6 @@ line-length = 110
 
 [tool.isort]
 profile = "black"
+
+[tool.mypy]
+ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ if __name__ == "__main__":
     setuptools.setup(
         name=__packagename__,
         packages=setuptools.find_packages(),
+        package_data={"bletl": ["py.typed"]},
         zip_safe=False,
         version=__version__,
         description="Package for parsing and transforming BioLector raw data.",


### PR DESCRIPTION
This adds `mypy` to the pre-commit and fixes a bunch of typing errors.
In some places this is achieved by adding `assert`s.

It also adds a `py.typed` file as per PEP 561 which lets `mypy` know that it can rely on `bletl` type hints when `bletl` is used in other projects.