### PR TITLE
Drop support for PyMC <5

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.10", "3.11"]
-        pymc-version: ["without", "'pymc>=4.2.2,<5'", "'pymc>=5.0.0'"]
+        pymc-version: ["without", "'pymc>=5.0.0'"]
     steps:
     - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}

--- a/bletl/__init__.py
+++ b/bletl/__init__.py
@@ -19,4 +19,4 @@ from .types import (
     NoMeasurementData,
 )
 
-__version__ = "1.3.1"
+__version__ = "1.4.0"

--- a/bletl/growth.py
+++ b/bletl/growth.py
@@ -1,18 +1,12 @@
 import logging
-import typing
 from typing import Dict, Optional, Sequence, Tuple, Union
 
 import arviz
 import calibr8
 import numpy
 import pymc as pm
+import pytensor.tensor as pt
 from packaging import version
-
-try:
-    import pytensor.tensor as pt
-except ModuleNotFoundError:
-    import aesara.tensor as pt  # type: ignore
-
 
 _log = logging.getLogger(__file__)
 
@@ -198,8 +192,8 @@ def _make_random_walk(
     """
     pmversion = version.parse(pm.__version__)
 
-    if pmversion < version.parse("4.2.2"):
-        raise NotImplementedError("PyMC versions <4.2.2 are no longer supported.")
+    if pmversion < version.parse("5.0.0"):
+        raise NotImplementedError("PyMC versions <5.0.0 are no longer supported.")
 
     if student_t:
         innov_dist = pm.StudentT.dist(mu=mu, sigma=sigma, nu=nu)


### PR DESCRIPTION
Due to [calibr8 v7.1.0](https://github.com/JuBiotech/calibr8/releases/tag/v7.1.0) already having dropped it, and the CI pipeline failing as a consequence.