### PR TITLE
Fix parsing of BioLector Pro datasets with filter id 401 or fluidics data for 48-well plates

### DIFF
--- a/bletl/__init__.py
+++ b/bletl/__init__.py
@@ -36,4 +36,4 @@ from .types import (
     NoMeasurementData,
 )
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"

--- a/bletl/parsing/blpro.py
+++ b/bletl/parsing/blpro.py
@@ -53,7 +53,7 @@ _WELL_NUMM_TO_ID = {
     for rownumber, row in enumerate("ABCDEF")
     for colnumber, column in enumerate(reversed(range(1, 9)) if rownumber % 2 else range(1, 9))
 }
-"""Maps 1-based well numbers in non-microfluidic mode by **measurement counting order** (→→→ ↓ ←←← ↓ →→→ ...) to alphanumeric well IDs."""
+"""Maps 1-based well numbers in non-MF mode by **measurement counting order** (→→→ ↓ ←←← ↓ →→→ ...) to alphanumeric well IDs."""
 
 
 class BioLectorProParser(BLDParser):

--- a/bletl/parsing/blpro.py
+++ b/bletl/parsing/blpro.py
@@ -229,6 +229,7 @@ def extract_filtersets(metadata):
         "201": "Biomass",
         "202": "pH(HP8)",
         "203": "DO(PSt3)",
+        "401": "Biomass",
     }
     for fnum, fset in filtersets.items():
         for k in ["reference_value", "reference_gain", "gain"]:

--- a/tests/data/BLPro/issue70.csv
+++ b/tests/data/BLPro/issue70.csv
@@ -1,0 +1,3971 @@
+=====process=====
+[process] 72
+[start_date_time] 2024-01-01, 12:00:00
+[hardware_id] B2-10-1004-0079
+[file_version_number] 0.0.0
+[internal_referencing] 1
+[hmi_version] 1.135
+[is_compressed] 1
+[referencing] 2
+[01_reference_value_Biomass] 1.234
+[02_reference_value_pH(LG1)] 100.000000
+[03_reference_value_DO(RF)] 100.000000
+[04_reference_value_Biomass] 1.234
+[05_reference_value_eCFP] 1.234
+[01_reference_gain_Biomass] 1
+[04_reference_gain_Biomass] 2
+[05_reference_gain_eCFP] 3
+[02_gain_pH(LG1)] 4
+[03_gain_DO(RF)] 5
+=====protocol=====
+====== main ======
+[name] ParserBug
+[final] False
+[user]
+[comment]
+[mtp] MTP_48-FlowerPlate
+[mtp-rows] 6
+[mtp-columns] 8
+[mtp-lot] 2207201
+[layout] 48empty
+[biolection_version] 3.20.3.0-cbb6738abf31b45c3bbd654d1000ca57bfd1363b
+====== channels ======
+[no_filterset] 5
+===== measurement channels =====
+[01_no] 1
+[01_name] Biomass1
+[01_filter_id] 401
+[01_filter_type] Intensity
+[01_gain_1] 1
+[01_gain_2] 1
+[01_calibration]
+===== measurement channels =====
+[02_no] 2
+[02_name] pH(LG1)
+[02_filter_id] 421
+[02_filter_type] pH
+[02_gain_1] 8
+[02_gain_2] 1
+[02_calibration] 2207201_comp
+===== measurement channels =====
+[03_no] 3
+[03_name] DO(RF)
+[03_filter_id] 428
+[03_filter_type] DO
+[03_gain_1] 4
+[03_gain_2] 1
+[03_calibration] 2207201_comp
+===== measurement channels =====
+[04_no] 4
+[04_name] Biomass2
+[04_filter_id] 401
+[04_filter_type] Intensity
+[04_gain_1] 2
+[04_gain_2] 1
+[04_calibration]
+===== measurement channels =====
+[05_no] 5
+[05_name] eCFP
+[05_filter_id] 443
+[05_filter_type] Intensity
+[05_gain_1] 3
+[05_gain_2] 1
+[05_calibration]
+====== process ======
+[temperature] 30
+[humidity] 85
+[frequency] 1300
+[cycle-time] 900
+[exp-time] 0
+[temp-after-exp] -1
+[o2] 35
+[co2] -1
+[evacuation-time] -1
+=====temperature-profile=====
+[no_temperature_points] 0
+=====humidity-profile=====
+[no_humidity_points] 0
+=====shaker-profile=====
+[no_shaker_points] 0
+=====co2-profile=====
+[no_co2_points] 0
+=====o2-profile=====
+[no_o2_points] 0
+=====cover-profile=====
+[no_cover_points] 0
+=====pause-profile=====
+[no_pause_points] 0
+=====LAM=====
+[lam_mode] 0
+====== microfluidics settings ======
+[microfluidics] 0
+====== fermentations ======
+[no_fermentation] 48
+===== fermentation =====
+[001_well] A01
+[001_content] X1
+[001_description]
+[001_s_vol] 0
+==== measurements ====
+=== measurement ===
+[001_01_measure] 1
+[001_01_x] 16
+[001_01_y] 9.5
+== calibration ==
+[001_01_cal-mode] NONE
+=== measurement ===
+[001_02_measure] 1
+[001_02_x] 18.5
+[001_02_y] 7
+== calibration ==
+[001_02_cal-mode] PH
+[001_02_temp-comp] 1
+[001_02_temp_min] 10
+[001_02_temp_max] 90
+[001_02_fmin_a] 12.34
+[001_02_fmin_m] -1.23
+[001_02_fmax_a] 12.34
+[001_02_fmax_m] -1.23
+[001_02_ph0_a] 1.234
+[001_02_ph0_m] -1.234
+[001_02_dph_a] 1.234
+[001_02_dph_m] 1.234
+=== measurement ===
+[001_03_measure] 1
+[001_03_x] 18.5
+[001_03_y] 12
+== calibration ==
+[001_03_cal-mode] DO
+[001_03_temp-comp] 1
+[001_03_temp_min] 10
+[001_03_temp_max] 90
+[001_03_k0_m] -0.123
+[001_03_k0_a] 12.3456
+[001_03_k100_m] -0.123
+[001_03_k100_a] 12.345
+=== measurement ===
+[001_04_measure] 1
+[001_04_x] 16
+[001_04_y] 9.5
+== calibration ==
+[001_04_cal-mode] NONE
+=== measurement ===
+[001_05_measure] 1
+[001_05_x] 16
+[001_05_y] 9.5
+== calibration ==
+[001_05_cal-mode] NONE
+===== fermentation =====
+[002_well] A02
+[002_content] X2
+[002_description]
+[002_s_vol] 0
+==== measurements ====
+=== measurement ===
+[002_01_measure] 1
+[002_01_x] 29
+[002_01_y] 9.5
+== calibration ==
+[002_01_cal-mode] NONE
+=== measurement ===
+[002_02_measure] 1
+[002_02_x] 31.5
+[002_02_y] 7
+== calibration ==
+[002_02_cal-mode] PH
+[002_02_temp-comp] 1
+[002_02_temp_min] 10
+[002_02_temp_max] 90
+[002_02_fmin_a] 12.34
+[002_02_fmin_m] -1.23
+[002_02_fmax_a] 12.34
+[002_02_fmax_m] -1.23
+[002_02_ph0_a] 1.234
+[002_02_ph0_m] -1.234
+[002_02_dph_a] 1.234
+[002_02_dph_m] 1.234
+=== measurement ===
+[002_03_measure] 1
+[002_03_x] 31.5
+[002_03_y] 12
+== calibration ==
+[002_03_cal-mode] DO
+[002_03_temp-comp] 1
+[002_03_temp_min] 10
+[002_03_temp_max] 90
+[002_03_k0_m] -0.123
+[002_03_k0_a] 12.3456
+[002_03_k100_m] -0.123
+[002_03_k100_a] 12.345
+=== measurement ===
+[002_04_measure] 1
+[002_04_x] 29
+[002_04_y] 9.5
+== calibration ==
+[002_04_cal-mode] NONE
+=== measurement ===
+[002_05_measure] 1
+[002_05_x] 29
+[002_05_y] 9.5
+== calibration ==
+[002_05_cal-mode] NONE
+===== fermentation =====
+[003_well] A03
+[003_content] X3
+[003_description]
+[003_s_vol] 0
+==== measurements ====
+=== measurement ===
+[003_01_measure] 1
+[003_01_x] 42
+[003_01_y] 9.5
+== calibration ==
+[003_01_cal-mode] NONE
+=== measurement ===
+[003_02_measure] 1
+[003_02_x] 44.5
+[003_02_y] 7
+== calibration ==
+[003_02_cal-mode] PH
+[003_02_temp-comp] 1
+[003_02_temp_min] 10
+[003_02_temp_max] 90
+[003_02_fmin_a] 12.34
+[003_02_fmin_m] -1.23
+[003_02_fmax_a] 12.34
+[003_02_fmax_m] -1.23
+[003_02_ph0_a] 1.234
+[003_02_ph0_m] -1.234
+[003_02_dph_a] 1.234
+[003_02_dph_m] 1.234
+=== measurement ===
+[003_03_measure] 1
+[003_03_x] 44.5
+[003_03_y] 12
+== calibration ==
+[003_03_cal-mode] DO
+[003_03_temp-comp] 1
+[003_03_temp_min] 10
+[003_03_temp_max] 90
+[003_03_k0_m] -0.123
+[003_03_k0_a] 12.3456
+[003_03_k100_m] -0.123
+[003_03_k100_a] 12.345
+=== measurement ===
+[003_04_measure] 1
+[003_04_x] 42
+[003_04_y] 9.5
+== calibration ==
+[003_04_cal-mode] NONE
+=== measurement ===
+[003_05_measure] 1
+[003_05_x] 42
+[003_05_y] 9.5
+== calibration ==
+[003_05_cal-mode] NONE
+===== fermentation =====
+[004_well] A04
+[004_content] X4
+[004_description]
+[004_s_vol] 0
+==== measurements ====
+=== measurement ===
+[004_01_measure] 1
+[004_01_x] 55
+[004_01_y] 9.5
+== calibration ==
+[004_01_cal-mode] NONE
+=== measurement ===
+[004_02_measure] 1
+[004_02_x] 57.5
+[004_02_y] 7
+== calibration ==
+[004_02_cal-mode] PH
+[004_02_temp-comp] 1
+[004_02_temp_min] 10
+[004_02_temp_max] 90
+[004_02_fmin_a] 12.34
+[004_02_fmin_m] -1.23
+[004_02_fmax_a] 12.34
+[004_02_fmax_m] -1.23
+[004_02_ph0_a] 1.234
+[004_02_ph0_m] -1.234
+[004_02_dph_a] 1.234
+[004_02_dph_m] 1.234
+=== measurement ===
+[004_03_measure] 1
+[004_03_x] 57.5
+[004_03_y] 12
+== calibration ==
+[004_03_cal-mode] DO
+[004_03_temp-comp] 1
+[004_03_temp_min] 10
+[004_03_temp_max] 90
+[004_03_k0_m] -0.123
+[004_03_k0_a] 12.3456
+[004_03_k100_m] -0.123
+[004_03_k100_a] 12.345
+=== measurement ===
+[004_04_measure] 1
+[004_04_x] 55
+[004_04_y] 9.5
+== calibration ==
+[004_04_cal-mode] NONE
+=== measurement ===
+[004_05_measure] 1
+[004_05_x] 55
+[004_05_y] 9.5
+== calibration ==
+[004_05_cal-mode] NONE
+===== fermentation =====
+[005_well] A05
+[005_content] X5
+[005_description]
+[005_s_vol] 0
+==== measurements ====
+=== measurement ===
+[005_01_measure] 1
+[005_01_x] 68
+[005_01_y] 9.5
+== calibration ==
+[005_01_cal-mode] NONE
+=== measurement ===
+[005_02_measure] 1
+[005_02_x] 70.5
+[005_02_y] 7
+== calibration ==
+[005_02_cal-mode] PH
+[005_02_temp-comp] 1
+[005_02_temp_min] 10
+[005_02_temp_max] 90
+[005_02_fmin_a] 12.34
+[005_02_fmin_m] -1.23
+[005_02_fmax_a] 12.34
+[005_02_fmax_m] -1.23
+[005_02_ph0_a] 1.234
+[005_02_ph0_m] -1.234
+[005_02_dph_a] 1.234
+[005_02_dph_m] 1.234
+=== measurement ===
+[005_03_measure] 1
+[005_03_x] 70.5
+[005_03_y] 12
+== calibration ==
+[005_03_cal-mode] DO
+[005_03_temp-comp] 1
+[005_03_temp_min] 10
+[005_03_temp_max] 90
+[005_03_k0_m] -0.123
+[005_03_k0_a] 12.3456
+[005_03_k100_m] -0.123
+[005_03_k100_a] 12.345
+=== measurement ===
+[005_04_measure] 1
+[005_04_x] 68
+[005_04_y] 9.5
+== calibration ==
+[005_04_cal-mode] NONE
+=== measurement ===
+[005_05_measure] 1
+[005_05_x] 68
+[005_05_y] 9.5
+== calibration ==
+[005_05_cal-mode] NONE
+===== fermentation =====
+[006_well] A06
+[006_content] X6
+[006_description]
+[006_s_vol] 0
+==== measurements ====
+=== measurement ===
+[006_01_measure] 1
+[006_01_x] 81
+[006_01_y] 9.5
+== calibration ==
+[006_01_cal-mode] NONE
+=== measurement ===
+[006_02_measure] 1
+[006_02_x] 83.5
+[006_02_y] 7
+== calibration ==
+[006_02_cal-mode] PH
+[006_02_temp-comp] 1
+[006_02_temp_min] 10
+[006_02_temp_max] 90
+[006_02_fmin_a] 12.34
+[006_02_fmin_m] -1.23
+[006_02_fmax_a] 12.34
+[006_02_fmax_m] -1.23
+[006_02_ph0_a] 1.234
+[006_02_ph0_m] -1.234
+[006_02_dph_a] 1.234
+[006_02_dph_m] 1.234
+=== measurement ===
+[006_03_measure] 1
+[006_03_x] 83.5
+[006_03_y] 12
+== calibration ==
+[006_03_cal-mode] DO
+[006_03_temp-comp] 1
+[006_03_temp_min] 10
+[006_03_temp_max] 90
+[006_03_k0_m] -0.123
+[006_03_k0_a] 12.3456
+[006_03_k100_m] -0.123
+[006_03_k100_a] 12.345
+=== measurement ===
+[006_04_measure] 1
+[006_04_x] 81
+[006_04_y] 9.5
+== calibration ==
+[006_04_cal-mode] NONE
+=== measurement ===
+[006_05_measure] 1
+[006_05_x] 81
+[006_05_y] 9.5
+== calibration ==
+[006_05_cal-mode] NONE
+===== fermentation =====
+[007_well] A07
+[007_content] X7
+[007_description]
+[007_s_vol] 0
+==== measurements ====
+=== measurement ===
+[007_01_measure] 1
+[007_01_x] 94
+[007_01_y] 9.5
+== calibration ==
+[007_01_cal-mode] NONE
+=== measurement ===
+[007_02_measure] 1
+[007_02_x] 96.5
+[007_02_y] 7
+== calibration ==
+[007_02_cal-mode] PH
+[007_02_temp-comp] 1
+[007_02_temp_min] 10
+[007_02_temp_max] 90
+[007_02_fmin_a] 12.34
+[007_02_fmin_m] -1.23
+[007_02_fmax_a] 12.34
+[007_02_fmax_m] -1.23
+[007_02_ph0_a] 1.234
+[007_02_ph0_m] -1.234
+[007_02_dph_a] 1.234
+[007_02_dph_m] 1.234
+=== measurement ===
+[007_03_measure] 1
+[007_03_x] 96.5
+[007_03_y] 12
+== calibration ==
+[007_03_cal-mode] DO
+[007_03_temp-comp] 1
+[007_03_temp_min] 10
+[007_03_temp_max] 90
+[007_03_k0_m] -0.123
+[007_03_k0_a] 12.3456
+[007_03_k100_m] -0.123
+[007_03_k100_a] 12.345
+=== measurement ===
+[007_04_measure] 1
+[007_04_x] 94
+[007_04_y] 9.5
+== calibration ==
+[007_04_cal-mode] NONE
+=== measurement ===
+[007_05_measure] 1
+[007_05_x] 94
+[007_05_y] 9.5
+== calibration ==
+[007_05_cal-mode] NONE
+===== fermentation =====
+[008_well] A08
+[008_content] X8
+[008_description]
+[008_s_vol] 0
+==== measurements ====
+=== measurement ===
+[008_01_measure] 1
+[008_01_x] 107
+[008_01_y] 9.5
+== calibration ==
+[008_01_cal-mode] NONE
+=== measurement ===
+[008_02_measure] 1
+[008_02_x] 109.5
+[008_02_y] 7
+== calibration ==
+[008_02_cal-mode] PH
+[008_02_temp-comp] 1
+[008_02_temp_min] 10
+[008_02_temp_max] 90
+[008_02_fmin_a] 12.34
+[008_02_fmin_m] -1.23
+[008_02_fmax_a] 12.34
+[008_02_fmax_m] -1.23
+[008_02_ph0_a] 1.234
+[008_02_ph0_m] -1.234
+[008_02_dph_a] 1.234
+[008_02_dph_m] 1.234
+=== measurement ===
+[008_03_measure] 1
+[008_03_x] 109.5
+[008_03_y] 12
+== calibration ==
+[008_03_cal-mode] DO
+[008_03_temp-comp] 1
+[008_03_temp_min] 10
+[008_03_temp_max] 90
+[008_03_k0_m] -0.123
+[008_03_k0_a] 12.3456
+[008_03_k100_m] -0.123
+[008_03_k100_a] 12.345
+=== measurement ===
+[008_04_measure] 1
+[008_04_x] 107
+[008_04_y] 9.5
+== calibration ==
+[008_04_cal-mode] NONE
+=== measurement ===
+[008_05_measure] 1
+[008_05_x] 107
+[008_05_y] 9.5
+== calibration ==
+[008_05_cal-mode] NONE
+===== fermentation =====
+[009_well] B08
+[009_content] X16
+[009_description]
+[009_s_vol] 0
+==== measurements ====
+=== measurement ===
+[009_01_measure] 1
+[009_01_x] 107
+[009_01_y] 22.5
+== calibration ==
+[009_01_cal-mode] NONE
+=== measurement ===
+[009_02_measure] 1
+[009_02_x] 109.5
+[009_02_y] 20
+== calibration ==
+[009_02_cal-mode] PH
+[009_02_temp-comp] 1
+[009_02_temp_min] 10
+[009_02_temp_max] 90
+[009_02_fmin_a] 12.34
+[009_02_fmin_m] -1.23
+[009_02_fmax_a] 12.34
+[009_02_fmax_m] -1.23
+[009_02_ph0_a] 1.234
+[009_02_ph0_m] -1.234
+[009_02_dph_a] 1.234
+[009_02_dph_m] 1.234
+=== measurement ===
+[009_03_measure] 1
+[009_03_x] 109.5
+[009_03_y] 25
+== calibration ==
+[009_03_cal-mode] DO
+[009_03_temp-comp] 1
+[009_03_temp_min] 10
+[009_03_temp_max] 90
+[009_03_k0_m] -0.123
+[009_03_k0_a] 12.3456
+[009_03_k100_m] -0.123
+[009_03_k100_a] 12.345
+=== measurement ===
+[009_04_measure] 1
+[009_04_x] 107
+[009_04_y] 22.5
+== calibration ==
+[009_04_cal-mode] NONE
+=== measurement ===
+[009_05_measure] 1
+[009_05_x] 107
+[009_05_y] 22.5
+== calibration ==
+[009_05_cal-mode] NONE
+===== fermentation =====
+[010_well] B07
+[010_content] X15
+[010_description]
+[010_s_vol] 0
+==== measurements ====
+=== measurement ===
+[010_01_measure] 1
+[010_01_x] 94
+[010_01_y] 22.5
+== calibration ==
+[010_01_cal-mode] NONE
+=== measurement ===
+[010_02_measure] 1
+[010_02_x] 96.5
+[010_02_y] 20
+== calibration ==
+[010_02_cal-mode] PH
+[010_02_temp-comp] 1
+[010_02_temp_min] 10
+[010_02_temp_max] 90
+[010_02_fmin_a] 12.34
+[010_02_fmin_m] -1.23
+[010_02_fmax_a] 12.34
+[010_02_fmax_m] -1.23
+[010_02_ph0_a] 1.234
+[010_02_ph0_m] -1.234
+[010_02_dph_a] 1.234
+[010_02_dph_m] 1.234
+=== measurement ===
+[010_03_measure] 1
+[010_03_x] 96.5
+[010_03_y] 25
+== calibration ==
+[010_03_cal-mode] DO
+[010_03_temp-comp] 1
+[010_03_temp_min] 10
+[010_03_temp_max] 90
+[010_03_k0_m] -0.123
+[010_03_k0_a] 12.3456
+[010_03_k100_m] -0.123
+[010_03_k100_a] 12.345
+=== measurement ===
+[010_04_measure] 1
+[010_04_x] 94
+[010_04_y] 22.5
+== calibration ==
+[010_04_cal-mode] NONE
+=== measurement ===
+[010_05_measure] 1
+[010_05_x] 94
+[010_05_y] 22.5
+== calibration ==
+[010_05_cal-mode] NONE
+===== fermentation =====
+[011_well] B06
+[011_content] X14
+[011_description]
+[011_s_vol] 0
+==== measurements ====
+=== measurement ===
+[011_01_measure] 1
+[011_01_x] 81
+[011_01_y] 22.5
+== calibration ==
+[011_01_cal-mode] NONE
+=== measurement ===
+[011_02_measure] 1
+[011_02_x] 83.5
+[011_02_y] 20
+== calibration ==
+[011_02_cal-mode] PH
+[011_02_temp-comp] 1
+[011_02_temp_min] 10
+[011_02_temp_max] 90
+[011_02_fmin_a] 12.34
+[011_02_fmin_m] -1.23
+[011_02_fmax_a] 12.34
+[011_02_fmax_m] -1.23
+[011_02_ph0_a] 1.234
+[011_02_ph0_m] -1.234
+[011_02_dph_a] 1.234
+[011_02_dph_m] 1.234
+=== measurement ===
+[011_03_measure] 1
+[011_03_x] 83.5
+[011_03_y] 25
+== calibration ==
+[011_03_cal-mode] DO
+[011_03_temp-comp] 1
+[011_03_temp_min] 10
+[011_03_temp_max] 90
+[011_03_k0_m] -0.123
+[011_03_k0_a] 12.3456
+[011_03_k100_m] -0.123
+[011_03_k100_a] 12.345
+=== measurement ===
+[011_04_measure] 1
+[011_04_x] 81
+[011_04_y] 22.5
+== calibration ==
+[011_04_cal-mode] NONE
+=== measurement ===
+[011_05_measure] 1
+[011_05_x] 81
+[011_05_y] 22.5
+== calibration ==
+[011_05_cal-mode] NONE
+===== fermentation =====
+[012_well] B05
+[012_content] X13
+[012_description]
+[012_s_vol] 0
+==== measurements ====
+=== measurement ===
+[012_01_measure] 1
+[012_01_x] 68
+[012_01_y] 22.5
+== calibration ==
+[012_01_cal-mode] NONE
+=== measurement ===
+[012_02_measure] 1
+[012_02_x] 70.5
+[012_02_y] 20
+== calibration ==
+[012_02_cal-mode] PH
+[012_02_temp-comp] 1
+[012_02_temp_min] 10
+[012_02_temp_max] 90
+[012_02_fmin_a] 12.34
+[012_02_fmin_m] -1.23
+[012_02_fmax_a] 12.34
+[012_02_fmax_m] -1.23
+[012_02_ph0_a] 1.234
+[012_02_ph0_m] -1.234
+[012_02_dph_a] 1.234
+[012_02_dph_m] 1.234
+=== measurement ===
+[012_03_measure] 1
+[012_03_x] 70.5
+[012_03_y] 25
+== calibration ==
+[012_03_cal-mode] DO
+[012_03_temp-comp] 1
+[012_03_temp_min] 10
+[012_03_temp_max] 90
+[012_03_k0_m] -0.123
+[012_03_k0_a] 12.3456
+[012_03_k100_m] -0.123
+[012_03_k100_a] 12.345
+=== measurement ===
+[012_04_measure] 1
+[012_04_x] 68
+[012_04_y] 22.5
+== calibration ==
+[012_04_cal-mode] NONE
+=== measurement ===
+[012_05_measure] 1
+[012_05_x] 68
+[012_05_y] 22.5
+== calibration ==
+[012_05_cal-mode] NONE
+===== fermentation =====
+[013_well] B04
+[013_content] X12
+[013_description]
+[013_s_vol] 0
+==== measurements ====
+=== measurement ===
+[013_01_measure] 1
+[013_01_x] 55
+[013_01_y] 22.5
+== calibration ==
+[013_01_cal-mode] NONE
+=== measurement ===
+[013_02_measure] 1
+[013_02_x] 57.5
+[013_02_y] 20
+== calibration ==
+[013_02_cal-mode] PH
+[013_02_temp-comp] 1
+[013_02_temp_min] 10
+[013_02_temp_max] 90
+[013_02_fmin_a] 12.34
+[013_02_fmin_m] -1.23
+[013_02_fmax_a] 12.34
+[013_02_fmax_m] -1.23
+[013_02_ph0_a] 1.234
+[013_02_ph0_m] -1.234
+[013_02_dph_a] 1.234
+[013_02_dph_m] 1.234
+=== measurement ===
+[013_03_measure] 1
+[013_03_x] 57.5
+[013_03_y] 25
+== calibration ==
+[013_03_cal-mode] DO
+[013_03_temp-comp] 1
+[013_03_temp_min] 10
+[013_03_temp_max] 90
+[013_03_k0_m] -0.123
+[013_03_k0_a] 12.3456
+[013_03_k100_m] -0.123
+[013_03_k100_a] 12.345
+=== measurement ===
+[013_04_measure] 1
+[013_04_x] 55
+[013_04_y] 22.5
+== calibration ==
+[013_04_cal-mode] NONE
+=== measurement ===
+[013_05_measure] 1
+[013_05_x] 55
+[013_05_y] 22.5
+== calibration ==
+[013_05_cal-mode] NONE
+===== fermentation =====
+[014_well] B03
+[014_content] X11
+[014_description]
+[014_s_vol] 0
+==== measurements ====
+=== measurement ===
+[014_01_measure] 1
+[014_01_x] 42
+[014_01_y] 22.5
+== calibration ==
+[014_01_cal-mode] NONE
+=== measurement ===
+[014_02_measure] 1
+[014_02_x] 44.5
+[014_02_y] 20
+== calibration ==
+[014_02_cal-mode] PH
+[014_02_temp-comp] 1
+[014_02_temp_min] 10
+[014_02_temp_max] 90
+[014_02_fmin_a] 12.34
+[014_02_fmin_m] -1.23
+[014_02_fmax_a] 12.34
+[014_02_fmax_m] -1.23
+[014_02_ph0_a] 1.234
+[014_02_ph0_m] -1.234
+[014_02_dph_a] 1.234
+[014_02_dph_m] 1.234
+=== measurement ===
+[014_03_measure] 1
+[014_03_x] 44.5
+[014_03_y] 25
+== calibration ==
+[014_03_cal-mode] DO
+[014_03_temp-comp] 1
+[014_03_temp_min] 10
+[014_03_temp_max] 90
+[014_03_k0_m] -0.123
+[014_03_k0_a] 12.3456
+[014_03_k100_m] -0.123
+[014_03_k100_a] 12.345
+=== measurement ===
+[014_04_measure] 1
+[014_04_x] 42
+[014_04_y] 22.5
+== calibration ==
+[014_04_cal-mode] NONE
+=== measurement ===
+[014_05_measure] 1
+[014_05_x] 42
+[014_05_y] 22.5
+== calibration ==
+[014_05_cal-mode] NONE
+===== fermentation =====
+[015_well] B02
+[015_content] X10
+[015_description]
+[015_s_vol] 0
+==== measurements ====
+=== measurement ===
+[015_01_measure] 1
+[015_01_x] 29
+[015_01_y] 22.5
+== calibration ==
+[015_01_cal-mode] NONE
+=== measurement ===
+[015_02_measure] 1
+[015_02_x] 31.5
+[015_02_y] 20
+== calibration ==
+[015_02_cal-mode] PH
+[015_02_temp-comp] 1
+[015_02_temp_min] 10
+[015_02_temp_max] 90
+[015_02_fmin_a] 12.34
+[015_02_fmin_m] -1.23
+[015_02_fmax_a] 12.34
+[015_02_fmax_m] -1.23
+[015_02_ph0_a] 1.234
+[015_02_ph0_m] -1.234
+[015_02_dph_a] 1.234
+[015_02_dph_m] 1.234
+=== measurement ===
+[015_03_measure] 1
+[015_03_x] 31.5
+[015_03_y] 25
+== calibration ==
+[015_03_cal-mode] DO
+[015_03_temp-comp] 1
+[015_03_temp_min] 10
+[015_03_temp_max] 90
+[015_03_k0_m] -0.123
+[015_03_k0_a] 12.3456
+[015_03_k100_m] -0.123
+[015_03_k100_a] 12.345
+=== measurement ===
+[015_04_measure] 1
+[015_04_x] 29
+[015_04_y] 22.5
+== calibration ==
+[015_04_cal-mode] NONE
+=== measurement ===
+[015_05_measure] 1
+[015_05_x] 29
+[015_05_y] 22.5
+== calibration ==
+[015_05_cal-mode] NONE
+===== fermentation =====
+[016_well] B01
+[016_content] X9
+[016_description]
+[016_s_vol] 0
+==== measurements ====
+=== measurement ===
+[016_01_measure] 1
+[016_01_x] 16
+[016_01_y] 22.5
+== calibration ==
+[016_01_cal-mode] NONE
+=== measurement ===
+[016_02_measure] 1
+[016_02_x] 18.5
+[016_02_y] 20
+== calibration ==
+[016_02_cal-mode] PH
+[016_02_temp-comp] 1
+[016_02_temp_min] 10
+[016_02_temp_max] 90
+[016_02_fmin_a] 12.34
+[016_02_fmin_m] -1.23
+[016_02_fmax_a] 12.34
+[016_02_fmax_m] -1.23
+[016_02_ph0_a] 1.234
+[016_02_ph0_m] -1.234
+[016_02_dph_a] 1.234
+[016_02_dph_m] 1.234
+=== measurement ===
+[016_03_measure] 1
+[016_03_x] 18.5
+[016_03_y] 25
+== calibration ==
+[016_03_cal-mode] DO
+[016_03_temp-comp] 1
+[016_03_temp_min] 10
+[016_03_temp_max] 90
+[016_03_k0_m] -0.123
+[016_03_k0_a] 12.3456
+[016_03_k100_m] -0.123
+[016_03_k100_a] 12.345
+=== measurement ===
+[016_04_measure] 1
+[016_04_x] 16
+[016_04_y] 22.5
+== calibration ==
+[016_04_cal-mode] NONE
+=== measurement ===
+[016_05_measure] 1
+[016_05_x] 16
+[016_05_y] 22.5
+== calibration ==
+[016_05_cal-mode] NONE
+===== fermentation =====
+[017_well] C01
+[017_content] X17
+[017_description]
+[017_s_vol] 0
+==== measurements ====
+=== measurement ===
+[017_01_measure] 1
+[017_01_x] 16
+[017_01_y] 35.5
+== calibration ==
+[017_01_cal-mode] NONE
+=== measurement ===
+[017_02_measure] 1
+[017_02_x] 18.5
+[017_02_y] 33
+== calibration ==
+[017_02_cal-mode] PH
+[017_02_temp-comp] 1
+[017_02_temp_min] 10
+[017_02_temp_max] 90
+[017_02_fmin_a] 12.34
+[017_02_fmin_m] -1.23
+[017_02_fmax_a] 12.34
+[017_02_fmax_m] -1.23
+[017_02_ph0_a] 1.234
+[017_02_ph0_m] -1.234
+[017_02_dph_a] 1.234
+[017_02_dph_m] 1.234
+=== measurement ===
+[017_03_measure] 1
+[017_03_x] 18.5
+[017_03_y] 38
+== calibration ==
+[017_03_cal-mode] DO
+[017_03_temp-comp] 1
+[017_03_temp_min] 10
+[017_03_temp_max] 90
+[017_03_k0_m] -0.123
+[017_03_k0_a] 12.3456
+[017_03_k100_m] -0.123
+[017_03_k100_a] 12.345
+=== measurement ===
+[017_04_measure] 1
+[017_04_x] 16
+[017_04_y] 35.5
+== calibration ==
+[017_04_cal-mode] NONE
+=== measurement ===
+[017_05_measure] 1
+[017_05_x] 16
+[017_05_y] 35.5
+== calibration ==
+[017_05_cal-mode] NONE
+===== fermentation =====
+[018_well] C02
+[018_content] X18
+[018_description]
+[018_s_vol] 0
+==== measurements ====
+=== measurement ===
+[018_01_measure] 1
+[018_01_x] 29
+[018_01_y] 35.5
+== calibration ==
+[018_01_cal-mode] NONE
+=== measurement ===
+[018_02_measure] 1
+[018_02_x] 31.5
+[018_02_y] 33
+== calibration ==
+[018_02_cal-mode] PH
+[018_02_temp-comp] 1
+[018_02_temp_min] 10
+[018_02_temp_max] 90
+[018_02_fmin_a] 12.34
+[018_02_fmin_m] -1.23
+[018_02_fmax_a] 12.34
+[018_02_fmax_m] -1.23
+[018_02_ph0_a] 1.234
+[018_02_ph0_m] -1.234
+[018_02_dph_a] 1.234
+[018_02_dph_m] 1.234
+=== measurement ===
+[018_03_measure] 1
+[018_03_x] 31.5
+[018_03_y] 38
+== calibration ==
+[018_03_cal-mode] DO
+[018_03_temp-comp] 1
+[018_03_temp_min] 10
+[018_03_temp_max] 90
+[018_03_k0_m] -0.123
+[018_03_k0_a] 12.3456
+[018_03_k100_m] -0.123
+[018_03_k100_a] 12.345
+=== measurement ===
+[018_04_measure] 1
+[018_04_x] 29
+[018_04_y] 35.5
+== calibration ==
+[018_04_cal-mode] NONE
+=== measurement ===
+[018_05_measure] 1
+[018_05_x] 29
+[018_05_y] 35.5
+== calibration ==
+[018_05_cal-mode] NONE
+===== fermentation =====
+[019_well] C03
+[019_content] X19
+[019_description]
+[019_s_vol] 0
+==== measurements ====
+=== measurement ===
+[019_01_measure] 1
+[019_01_x] 42
+[019_01_y] 35.5
+== calibration ==
+[019_01_cal-mode] NONE
+=== measurement ===
+[019_02_measure] 1
+[019_02_x] 44.5
+[019_02_y] 33
+== calibration ==
+[019_02_cal-mode] PH
+[019_02_temp-comp] 1
+[019_02_temp_min] 10
+[019_02_temp_max] 90
+[019_02_fmin_a] 12.34
+[019_02_fmin_m] -1.23
+[019_02_fmax_a] 12.34
+[019_02_fmax_m] -1.23
+[019_02_ph0_a] 1.234
+[019_02_ph0_m] -1.234
+[019_02_dph_a] 1.234
+[019_02_dph_m] 1.234
+=== measurement ===
+[019_03_measure] 1
+[019_03_x] 44.5
+[019_03_y] 38
+== calibration ==
+[019_03_cal-mode] DO
+[019_03_temp-comp] 1
+[019_03_temp_min] 10
+[019_03_temp_max] 90
+[019_03_k0_m] -0.123
+[019_03_k0_a] 12.3456
+[019_03_k100_m] -0.123
+[019_03_k100_a] 12.345
+=== measurement ===
+[019_04_measure] 1
+[019_04_x] 42
+[019_04_y] 35.5
+== calibration ==
+[019_04_cal-mode] NONE
+=== measurement ===
+[019_05_measure] 1
+[019_05_x] 42
+[019_05_y] 35.5
+== calibration ==
+[019_05_cal-mode] NONE
+===== fermentation =====
+[020_well] C04
+[020_content] X20
+[020_description]
+[020_s_vol] 0
+==== measurements ====
+=== measurement ===
+[020_01_measure] 1
+[020_01_x] 55
+[020_01_y] 35.5
+== calibration ==
+[020_01_cal-mode] NONE
+=== measurement ===
+[020_02_measure] 1
+[020_02_x] 57.5
+[020_02_y] 33
+== calibration ==
+[020_02_cal-mode] PH
+[020_02_temp-comp] 1
+[020_02_temp_min] 10
+[020_02_temp_max] 90
+[020_02_fmin_a] 12.34
+[020_02_fmin_m] -1.23
+[020_02_fmax_a] 12.34
+[020_02_fmax_m] -1.23
+[020_02_ph0_a] 1.234
+[020_02_ph0_m] -1.234
+[020_02_dph_a] 1.234
+[020_02_dph_m] 1.234
+=== measurement ===
+[020_03_measure] 1
+[020_03_x] 57.5
+[020_03_y] 38
+== calibration ==
+[020_03_cal-mode] DO
+[020_03_temp-comp] 1
+[020_03_temp_min] 10
+[020_03_temp_max] 90
+[020_03_k0_m] -0.123
+[020_03_k0_a] 12.3456
+[020_03_k100_m] -0.123
+[020_03_k100_a] 12.345
+=== measurement ===
+[020_04_measure] 1
+[020_04_x] 55
+[020_04_y] 35.5
+== calibration ==
+[020_04_cal-mode] NONE
+=== measurement ===
+[020_05_measure] 1
+[020_05_x] 55
+[020_05_y] 35.5
+== calibration ==
+[020_05_cal-mode] NONE
+===== fermentation =====
+[021_well] C05
+[021_content] X21
+[021_description]
+[021_s_vol] 0
+==== measurements ====
+=== measurement ===
+[021_01_measure] 1
+[021_01_x] 68
+[021_01_y] 35.5
+== calibration ==
+[021_01_cal-mode] NONE
+=== measurement ===
+[021_02_measure] 1
+[021_02_x] 70.5
+[021_02_y] 33
+== calibration ==
+[021_02_cal-mode] PH
+[021_02_temp-comp] 1
+[021_02_temp_min] 10
+[021_02_temp_max] 90
+[021_02_fmin_a] 12.34
+[021_02_fmin_m] -1.23
+[021_02_fmax_a] 12.34
+[021_02_fmax_m] -1.23
+[021_02_ph0_a] 1.234
+[021_02_ph0_m] -1.234
+[021_02_dph_a] 1.234
+[021_02_dph_m] 1.234
+=== measurement ===
+[021_03_measure] 1
+[021_03_x] 70.5
+[021_03_y] 38
+== calibration ==
+[021_03_cal-mode] DO
+[021_03_temp-comp] 1
+[021_03_temp_min] 10
+[021_03_temp_max] 90
+[021_03_k0_m] -0.123
+[021_03_k0_a] 12.3456
+[021_03_k100_m] -0.123
+[021_03_k100_a] 12.345
+=== measurement ===
+[021_04_measure] 1
+[021_04_x] 68
+[021_04_y] 35.5
+== calibration ==
+[021_04_cal-mode] NONE
+=== measurement ===
+[021_05_measure] 1
+[021_05_x] 68
+[021_05_y] 35.5
+== calibration ==
+[021_05_cal-mode] NONE
+===== fermentation =====
+[022_well] C06
+[022_content] X22
+[022_description]
+[022_s_vol] 0
+==== measurements ====
+=== measurement ===
+[022_01_measure] 1
+[022_01_x] 81
+[022_01_y] 35.5
+== calibration ==
+[022_01_cal-mode] NONE
+=== measurement ===
+[022_02_measure] 1
+[022_02_x] 83.5
+[022_02_y] 33
+== calibration ==
+[022_02_cal-mode] PH
+[022_02_temp-comp] 1
+[022_02_temp_min] 10
+[022_02_temp_max] 90
+[022_02_fmin_a] 12.34
+[022_02_fmin_m] -1.23
+[022_02_fmax_a] 12.34
+[022_02_fmax_m] -1.23
+[022_02_ph0_a] 1.234
+[022_02_ph0_m] -1.234
+[022_02_dph_a] 1.234
+[022_02_dph_m] 1.234
+=== measurement ===
+[022_03_measure] 1
+[022_03_x] 83.5
+[022_03_y] 38
+== calibration ==
+[022_03_cal-mode] DO
+[022_03_temp-comp] 1
+[022_03_temp_min] 10
+[022_03_temp_max] 90
+[022_03_k0_m] -0.123
+[022_03_k0_a] 12.3456
+[022_03_k100_m] -0.123
+[022_03_k100_a] 12.345
+=== measurement ===
+[022_04_measure] 1
+[022_04_x] 81
+[022_04_y] 35.5
+== calibration ==
+[022_04_cal-mode] NONE
+=== measurement ===
+[022_05_measure] 1
+[022_05_x] 81
+[022_05_y] 35.5
+== calibration ==
+[022_05_cal-mode] NONE
+===== fermentation =====
+[023_well] C07
+[023_content] X23
+[023_description]
+[023_s_vol] 0
+==== measurements ====
+=== measurement ===
+[023_01_measure] 1
+[023_01_x] 94
+[023_01_y] 35.5
+== calibration ==
+[023_01_cal-mode] NONE
+=== measurement ===
+[023_02_measure] 1
+[023_02_x] 96.5
+[023_02_y] 33
+== calibration ==
+[023_02_cal-mode] PH
+[023_02_temp-comp] 1
+[023_02_temp_min] 10
+[023_02_temp_max] 90
+[023_02_fmin_a] 12.34
+[023_02_fmin_m] -1.23
+[023_02_fmax_a] 12.34
+[023_02_fmax_m] -1.23
+[023_02_ph0_a] 1.234
+[023_02_ph0_m] -1.234
+[023_02_dph_a] 1.234
+[023_02_dph_m] 1.234
+=== measurement ===
+[023_03_measure] 1
+[023_03_x] 96.5
+[023_03_y] 38
+== calibration ==
+[023_03_cal-mode] DO
+[023_03_temp-comp] 1
+[023_03_temp_min] 10
+[023_03_temp_max] 90
+[023_03_k0_m] -0.123
+[023_03_k0_a] 12.3456
+[023_03_k100_m] -0.123
+[023_03_k100_a] 12.345
+=== measurement ===
+[023_04_measure] 1
+[023_04_x] 94
+[023_04_y] 35.5
+== calibration ==
+[023_04_cal-mode] NONE
+=== measurement ===
+[023_05_measure] 1
+[023_05_x] 94
+[023_05_y] 35.5
+== calibration ==
+[023_05_cal-mode] NONE
+===== fermentation =====
+[024_well] C08
+[024_content] X24
+[024_description]
+[024_s_vol] 0
+==== measurements ====
+=== measurement ===
+[024_01_measure] 1
+[024_01_x] 107
+[024_01_y] 35.5
+== calibration ==
+[024_01_cal-mode] NONE
+=== measurement ===
+[024_02_measure] 1
+[024_02_x] 109.5
+[024_02_y] 33
+== calibration ==
+[024_02_cal-mode] PH
+[024_02_temp-comp] 1
+[024_02_temp_min] 10
+[024_02_temp_max] 90
+[024_02_fmin_a] 12.34
+[024_02_fmin_m] -1.23
+[024_02_fmax_a] 12.34
+[024_02_fmax_m] -1.23
+[024_02_ph0_a] 1.234
+[024_02_ph0_m] -1.234
+[024_02_dph_a] 1.234
+[024_02_dph_m] 1.234
+=== measurement ===
+[024_03_measure] 1
+[024_03_x] 109.5
+[024_03_y] 38
+== calibration ==
+[024_03_cal-mode] DO
+[024_03_temp-comp] 1
+[024_03_temp_min] 10
+[024_03_temp_max] 90
+[024_03_k0_m] -0.123
+[024_03_k0_a] 12.3456
+[024_03_k100_m] -0.123
+[024_03_k100_a] 12.345
+=== measurement ===
+[024_04_measure] 1
+[024_04_x] 107
+[024_04_y] 35.5
+== calibration ==
+[024_04_cal-mode] NONE
+=== measurement ===
+[024_05_measure] 1
+[024_05_x] 107
+[024_05_y] 35.5
+== calibration ==
+[024_05_cal-mode] NONE
+===== fermentation =====
+[025_well] D08
+[025_content] X32
+[025_description]
+[025_s_vol] 0
+==== measurements ====
+=== measurement ===
+[025_01_measure] 1
+[025_01_x] 107
+[025_01_y] 48.5
+== calibration ==
+[025_01_cal-mode] NONE
+=== measurement ===
+[025_02_measure] 1
+[025_02_x] 109.5
+[025_02_y] 46
+== calibration ==
+[025_02_cal-mode] PH
+[025_02_temp-comp] 1
+[025_02_temp_min] 10
+[025_02_temp_max] 90
+[025_02_fmin_a] 12.34
+[025_02_fmin_m] -1.23
+[025_02_fmax_a] 12.34
+[025_02_fmax_m] -1.23
+[025_02_ph0_a] 1.234
+[025_02_ph0_m] -1.234
+[025_02_dph_a] 1.234
+[025_02_dph_m] 1.234
+=== measurement ===
+[025_03_measure] 1
+[025_03_x] 109.5
+[025_03_y] 51
+== calibration ==
+[025_03_cal-mode] DO
+[025_03_temp-comp] 1
+[025_03_temp_min] 10
+[025_03_temp_max] 90
+[025_03_k0_m] -0.123
+[025_03_k0_a] 12.3456
+[025_03_k100_m] -0.123
+[025_03_k100_a] 12.345
+=== measurement ===
+[025_04_measure] 1
+[025_04_x] 107
+[025_04_y] 48.5
+== calibration ==
+[025_04_cal-mode] NONE
+=== measurement ===
+[025_05_measure] 1
+[025_05_x] 107
+[025_05_y] 48.5
+== calibration ==
+[025_05_cal-mode] NONE
+===== fermentation =====
+[026_well] D07
+[026_content] X31
+[026_description]
+[026_s_vol] 0
+==== measurements ====
+=== measurement ===
+[026_01_measure] 1
+[026_01_x] 94
+[026_01_y] 48.5
+== calibration ==
+[026_01_cal-mode] NONE
+=== measurement ===
+[026_02_measure] 1
+[026_02_x] 96.5
+[026_02_y] 46
+== calibration ==
+[026_02_cal-mode] PH
+[026_02_temp-comp] 1
+[026_02_temp_min] 10
+[026_02_temp_max] 90
+[026_02_fmin_a] 12.34
+[026_02_fmin_m] -1.23
+[026_02_fmax_a] 12.34
+[026_02_fmax_m] -1.23
+[026_02_ph0_a] 1.234
+[026_02_ph0_m] -1.234
+[026_02_dph_a] 1.234
+[026_02_dph_m] 1.234
+=== measurement ===
+[026_03_measure] 1
+[026_03_x] 96.5
+[026_03_y] 51
+== calibration ==
+[026_03_cal-mode] DO
+[026_03_temp-comp] 1
+[026_03_temp_min] 10
+[026_03_temp_max] 90
+[026_03_k0_m] -0.123
+[026_03_k0_a] 12.3456
+[026_03_k100_m] -0.123
+[026_03_k100_a] 12.345
+=== measurement ===
+[026_04_measure] 1
+[026_04_x] 94
+[026_04_y] 48.5
+== calibration ==
+[026_04_cal-mode] NONE
+=== measurement ===
+[026_05_measure] 1
+[026_05_x] 94
+[026_05_y] 48.5
+== calibration ==
+[026_05_cal-mode] NONE
+===== fermentation =====
+[027_well] D06
+[027_content] X30
+[027_description]
+[027_s_vol] 0
+==== measurements ====
+=== measurement ===
+[027_01_measure] 1
+[027_01_x] 81
+[027_01_y] 48.5
+== calibration ==
+[027_01_cal-mode] NONE
+=== measurement ===
+[027_02_measure] 1
+[027_02_x] 83.5
+[027_02_y] 46
+== calibration ==
+[027_02_cal-mode] PH
+[027_02_temp-comp] 1
+[027_02_temp_min] 10
+[027_02_temp_max] 90
+[027_02_fmin_a] 12.34
+[027_02_fmin_m] -1.23
+[027_02_fmax_a] 12.34
+[027_02_fmax_m] -1.23
+[027_02_ph0_a] 1.234
+[027_02_ph0_m] -1.234
+[027_02_dph_a] 1.234
+[027_02_dph_m] 1.234
+=== measurement ===
+[027_03_measure] 1
+[027_03_x] 83.5
+[027_03_y] 51
+== calibration ==
+[027_03_cal-mode] DO
+[027_03_temp-comp] 1
+[027_03_temp_min] 10
+[027_03_temp_max] 90
+[027_03_k0_m] -0.123
+[027_03_k0_a] 12.3456
+[027_03_k100_m] -0.123
+[027_03_k100_a] 12.345
+=== measurement ===
+[027_04_measure] 1
+[027_04_x] 81
+[027_04_y] 48.5
+== calibration ==
+[027_04_cal-mode] NONE
+=== measurement ===
+[027_05_measure] 1
+[027_05_x] 81
+[027_05_y] 48.5
+== calibration ==
+[027_05_cal-mode] NONE
+===== fermentation =====
+[028_well] D05
+[028_content] X29
+[028_description]
+[028_s_vol] 0
+==== measurements ====
+=== measurement ===
+[028_01_measure] 1
+[028_01_x] 68
+[028_01_y] 48.5
+== calibration ==
+[028_01_cal-mode] NONE
+=== measurement ===
+[028_02_measure] 1
+[028_02_x] 70.5
+[028_02_y] 46
+== calibration ==
+[028_02_cal-mode] PH
+[028_02_temp-comp] 1
+[028_02_temp_min] 10
+[028_02_temp_max] 90
+[028_02_fmin_a] 12.34
+[028_02_fmin_m] -1.23
+[028_02_fmax_a] 12.34
+[028_02_fmax_m] -1.23
+[028_02_ph0_a] 1.234
+[028_02_ph0_m] -1.234
+[028_02_dph_a] 1.234
+[028_02_dph_m] 1.234
+=== measurement ===
+[028_03_measure] 1
+[028_03_x] 70.5
+[028_03_y] 51
+== calibration ==
+[028_03_cal-mode] DO
+[028_03_temp-comp] 1
+[028_03_temp_min] 10
+[028_03_temp_max] 90
+[028_03_k0_m] -0.123
+[028_03_k0_a] 12.3456
+[028_03_k100_m] -0.123
+[028_03_k100_a] 12.345
+=== measurement ===
+[028_04_measure] 1
+[028_04_x] 68
+[028_04_y] 48.5
+== calibration ==
+[028_04_cal-mode] NONE
+=== measurement ===
+[028_05_measure] 1
+[028_05_x] 68
+[028_05_y] 48.5
+== calibration ==
+[028_05_cal-mode] NONE
+===== fermentation =====
+[029_well] D04
+[029_content] X28
+[029_description]
+[029_s_vol] 0
+==== measurements ====
+=== measurement ===
+[029_01_measure] 1
+[029_01_x] 55
+[029_01_y] 48.5
+== calibration ==
+[029_01_cal-mode] NONE
+=== measurement ===
+[029_02_measure] 1
+[029_02_x] 57.5
+[029_02_y] 46
+== calibration ==
+[029_02_cal-mode] PH
+[029_02_temp-comp] 1
+[029_02_temp_min] 10
+[029_02_temp_max] 90
+[029_02_fmin_a] 12.34
+[029_02_fmin_m] -1.23
+[029_02_fmax_a] 12.34
+[029_02_fmax_m] -1.23
+[029_02_ph0_a] 1.234
+[029_02_ph0_m] -1.234
+[029_02_dph_a] 1.234
+[029_02_dph_m] 1.234
+=== measurement ===
+[029_03_measure] 1
+[029_03_x] 57.5
+[029_03_y] 51
+== calibration ==
+[029_03_cal-mode] DO
+[029_03_temp-comp] 1
+[029_03_temp_min] 10
+[029_03_temp_max] 90
+[029_03_k0_m] -0.123
+[029_03_k0_a] 12.3456
+[029_03_k100_m] -0.123
+[029_03_k100_a] 12.345
+=== measurement ===
+[029_04_measure] 1
+[029_04_x] 55
+[029_04_y] 48.5
+== calibration ==
+[029_04_cal-mode] NONE
+=== measurement ===
+[029_05_measure] 1
+[029_05_x] 55
+[029_05_y] 48.5
+== calibration ==
+[029_05_cal-mode] NONE
+===== fermentation =====
+[030_well] D03
+[030_content] X27
+[030_description]
+[030_s_vol] 0
+==== measurements ====
+=== measurement ===
+[030_01_measure] 1
+[030_01_x] 42
+[030_01_y] 48.5
+== calibration ==
+[030_01_cal-mode] NONE
+=== measurement ===
+[030_02_measure] 1
+[030_02_x] 44.5
+[030_02_y] 46
+== calibration ==
+[030_02_cal-mode] PH
+[030_02_temp-comp] 1
+[030_02_temp_min] 10
+[030_02_temp_max] 90
+[030_02_fmin_a] 12.34
+[030_02_fmin_m] -1.23
+[030_02_fmax_a] 12.34
+[030_02_fmax_m] -1.23
+[030_02_ph0_a] 1.234
+[030_02_ph0_m] -1.234
+[030_02_dph_a] 1.234
+[030_02_dph_m] 1.234
+=== measurement ===
+[030_03_measure] 1
+[030_03_x] 44.5
+[030_03_y] 51
+== calibration ==
+[030_03_cal-mode] DO
+[030_03_temp-comp] 1
+[030_03_temp_min] 10
+[030_03_temp_max] 90
+[030_03_k0_m] -0.123
+[030_03_k0_a] 12.3456
+[030_03_k100_m] -0.123
+[030_03_k100_a] 12.345
+=== measurement ===
+[030_04_measure] 1
+[030_04_x] 42
+[030_04_y] 48.5
+== calibration ==
+[030_04_cal-mode] NONE
+=== measurement ===
+[030_05_measure] 1
+[030_05_x] 42
+[030_05_y] 48.5
+== calibration ==
+[030_05_cal-mode] NONE
+===== fermentation =====
+[031_well] D02
+[031_content] X26
+[031_description]
+[031_s_vol] 0
+==== measurements ====
+=== measurement ===
+[031_01_measure] 1
+[031_01_x] 29
+[031_01_y] 48.5
+== calibration ==
+[031_01_cal-mode] NONE
+=== measurement ===
+[031_02_measure] 1
+[031_02_x] 31.5
+[031_02_y] 46
+== calibration ==
+[031_02_cal-mode] PH
+[031_02_temp-comp] 1
+[031_02_temp_min] 10
+[031_02_temp_max] 90
+[031_02_fmin_a] 12.34
+[031_02_fmin_m] -1.23
+[031_02_fmax_a] 12.34
+[031_02_fmax_m] -1.23
+[031_02_ph0_a] 1.234
+[031_02_ph0_m] -1.234
+[031_02_dph_a] 1.234
+[031_02_dph_m] 1.234
+=== measurement ===
+[031_03_measure] 1
+[031_03_x] 31.5
+[031_03_y] 51
+== calibration ==
+[031_03_cal-mode] DO
+[031_03_temp-comp] 1
+[031_03_temp_min] 10
+[031_03_temp_max] 90
+[031_03_k0_m] -0.123
+[031_03_k0_a] 12.3456
+[031_03_k100_m] -0.123
+[031_03_k100_a] 12.345
+=== measurement ===
+[031_04_measure] 1
+[031_04_x] 29
+[031_04_y] 48.5
+== calibration ==
+[031_04_cal-mode] NONE
+=== measurement ===
+[031_05_measure] 1
+[031_05_x] 29
+[031_05_y] 48.5
+== calibration ==
+[031_05_cal-mode] NONE
+===== fermentation =====
+[032_well] D01
+[032_content] X25
+[032_description]
+[032_s_vol] 0
+==== measurements ====
+=== measurement ===
+[032_01_measure] 1
+[032_01_x] 16
+[032_01_y] 48.5
+== calibration ==
+[032_01_cal-mode] NONE
+=== measurement ===
+[032_02_measure] 1
+[032_02_x] 18.5
+[032_02_y] 46
+== calibration ==
+[032_02_cal-mode] PH
+[032_02_temp-comp] 1
+[032_02_temp_min] 10
+[032_02_temp_max] 90
+[032_02_fmin_a] 12.34
+[032_02_fmin_m] -1.23
+[032_02_fmax_a] 12.34
+[032_02_fmax_m] -1.23
+[032_02_ph0_a] 1.234
+[032_02_ph0_m] -1.234
+[032_02_dph_a] 1.234
+[032_02_dph_m] 1.234
+=== measurement ===
+[032_03_measure] 1
+[032_03_x] 18.5
+[032_03_y] 51
+== calibration ==
+[032_03_cal-mode] DO
+[032_03_temp-comp] 1
+[032_03_temp_min] 10
+[032_03_temp_max] 90
+[032_03_k0_m] -0.123
+[032_03_k0_a] 12.3456
+[032_03_k100_m] -0.123
+[032_03_k100_a] 12.345
+=== measurement ===
+[032_04_measure] 1
+[032_04_x] 16
+[032_04_y] 48.5
+== calibration ==
+[032_04_cal-mode] NONE
+=== measurement ===
+[032_05_measure] 1
+[032_05_x] 16
+[032_05_y] 48.5
+== calibration ==
+[032_05_cal-mode] NONE
+===== fermentation =====
+[033_well] E01
+[033_content] X33
+[033_description]
+[033_s_vol] 0
+==== measurements ====
+=== measurement ===
+[033_01_measure] 1
+[033_01_x] 16
+[033_01_y] 61.5
+== calibration ==
+[033_01_cal-mode] NONE
+=== measurement ===
+[033_02_measure] 1
+[033_02_x] 18.5
+[033_02_y] 59
+== calibration ==
+[033_02_cal-mode] PH
+[033_02_temp-comp] 1
+[033_02_temp_min] 10
+[033_02_temp_max] 90
+[033_02_fmin_a] 12.34
+[033_02_fmin_m] -1.23
+[033_02_fmax_a] 12.34
+[033_02_fmax_m] -1.23
+[033_02_ph0_a] 1.234
+[033_02_ph0_m] -1.234
+[033_02_dph_a] 1.234
+[033_02_dph_m] 1.234
+=== measurement ===
+[033_03_measure] 1
+[033_03_x] 18.5
+[033_03_y] 64
+== calibration ==
+[033_03_cal-mode] DO
+[033_03_temp-comp] 1
+[033_03_temp_min] 10
+[033_03_temp_max] 90
+[033_03_k0_m] -0.123
+[033_03_k0_a] 12.3456
+[033_03_k100_m] -0.123
+[033_03_k100_a] 12.345
+=== measurement ===
+[033_04_measure] 1
+[033_04_x] 16
+[033_04_y] 61.5
+== calibration ==
+[033_04_cal-mode] NONE
+=== measurement ===
+[033_05_measure] 1
+[033_05_x] 16
+[033_05_y] 61.5
+== calibration ==
+[033_05_cal-mode] NONE
+===== fermentation =====
+[034_well] E02
+[034_content] X34
+[034_description]
+[034_s_vol] 0
+==== measurements ====
+=== measurement ===
+[034_01_measure] 1
+[034_01_x] 29
+[034_01_y] 61.5
+== calibration ==
+[034_01_cal-mode] NONE
+=== measurement ===
+[034_02_measure] 1
+[034_02_x] 31.5
+[034_02_y] 59
+== calibration ==
+[034_02_cal-mode] PH
+[034_02_temp-comp] 1
+[034_02_temp_min] 10
+[034_02_temp_max] 90
+[034_02_fmin_a] 12.34
+[034_02_fmin_m] -1.23
+[034_02_fmax_a] 12.34
+[034_02_fmax_m] -1.23
+[034_02_ph0_a] 1.234
+[034_02_ph0_m] -1.234
+[034_02_dph_a] 1.234
+[034_02_dph_m] 1.234
+=== measurement ===
+[034_03_measure] 1
+[034_03_x] 31.5
+[034_03_y] 64
+== calibration ==
+[034_03_cal-mode] DO
+[034_03_temp-comp] 1
+[034_03_temp_min] 10
+[034_03_temp_max] 90
+[034_03_k0_m] -0.123
+[034_03_k0_a] 12.3456
+[034_03_k100_m] -0.123
+[034_03_k100_a] 12.345
+=== measurement ===
+[034_04_measure] 1
+[034_04_x] 29
+[034_04_y] 61.5
+== calibration ==
+[034_04_cal-mode] NONE
+=== measurement ===
+[034_05_measure] 1
+[034_05_x] 29
+[034_05_y] 61.5
+== calibration ==
+[034_05_cal-mode] NONE
+===== fermentation =====
+[035_well] E03
+[035_content] X35
+[035_description]
+[035_s_vol] 0
+==== measurements ====
+=== measurement ===
+[035_01_measure] 1
+[035_01_x] 42
+[035_01_y] 61.5
+== calibration ==
+[035_01_cal-mode] NONE
+=== measurement ===
+[035_02_measure] 1
+[035_02_x] 44.5
+[035_02_y] 59
+== calibration ==
+[035_02_cal-mode] PH
+[035_02_temp-comp] 1
+[035_02_temp_min] 10
+[035_02_temp_max] 90
+[035_02_fmin_a] 12.34
+[035_02_fmin_m] -1.23
+[035_02_fmax_a] 12.34
+[035_02_fmax_m] -1.23
+[035_02_ph0_a] 1.234
+[035_02_ph0_m] -1.234
+[035_02_dph_a] 1.234
+[035_02_dph_m] 1.234
+=== measurement ===
+[035_03_measure] 1
+[035_03_x] 44.5
+[035_03_y] 64
+== calibration ==
+[035_03_cal-mode] DO
+[035_03_temp-comp] 1
+[035_03_temp_min] 10
+[035_03_temp_max] 90
+[035_03_k0_m] -0.123
+[035_03_k0_a] 12.3456
+[035_03_k100_m] -0.123
+[035_03_k100_a] 12.345
+=== measurement ===
+[035_04_measure] 1
+[035_04_x] 42
+[035_04_y] 61.5
+== calibration ==
+[035_04_cal-mode] NONE
+=== measurement ===
+[035_05_measure] 1
+[035_05_x] 42
+[035_05_y] 61.5
+== calibration ==
+[035_05_cal-mode] NONE
+===== fermentation =====
+[036_well] E04
+[036_content] X36
+[036_description]
+[036_s_vol] 0
+==== measurements ====
+=== measurement ===
+[036_01_measure] 1
+[036_01_x] 55
+[036_01_y] 61.5
+== calibration ==
+[036_01_cal-mode] NONE
+=== measurement ===
+[036_02_measure] 1
+[036_02_x] 57.5
+[036_02_y] 59
+== calibration ==
+[036_02_cal-mode] PH
+[036_02_temp-comp] 1
+[036_02_temp_min] 10
+[036_02_temp_max] 90
+[036_02_fmin_a] 12.34
+[036_02_fmin_m] -1.23
+[036_02_fmax_a] 12.34
+[036_02_fmax_m] -1.23
+[036_02_ph0_a] 1.234
+[036_02_ph0_m] -1.234
+[036_02_dph_a] 1.234
+[036_02_dph_m] 1.234
+=== measurement ===
+[036_03_measure] 1
+[036_03_x] 57.5
+[036_03_y] 64
+== calibration ==
+[036_03_cal-mode] DO
+[036_03_temp-comp] 1
+[036_03_temp_min] 10
+[036_03_temp_max] 90
+[036_03_k0_m] -0.123
+[036_03_k0_a] 12.3456
+[036_03_k100_m] -0.123
+[036_03_k100_a] 12.345
+=== measurement ===
+[036_04_measure] 1
+[036_04_x] 55
+[036_04_y] 61.5
+== calibration ==
+[036_04_cal-mode] NONE
+=== measurement ===
+[036_05_measure] 1
+[036_05_x] 55
+[036_05_y] 61.5
+== calibration ==
+[036_05_cal-mode] NONE
+===== fermentation =====
+[037_well] E05
+[037_content] X37
+[037_description]
+[037_s_vol] 0
+==== measurements ====
+=== measurement ===
+[037_01_measure] 1
+[037_01_x] 68
+[037_01_y] 61.5
+== calibration ==
+[037_01_cal-mode] NONE
+=== measurement ===
+[037_02_measure] 1
+[037_02_x] 70.5
+[037_02_y] 59
+== calibration ==
+[037_02_cal-mode] PH
+[037_02_temp-comp] 1
+[037_02_temp_min] 10
+[037_02_temp_max] 90
+[037_02_fmin_a] 12.34
+[037_02_fmin_m] -1.23
+[037_02_fmax_a] 12.34
+[037_02_fmax_m] -1.23
+[037_02_ph0_a] 1.234
+[037_02_ph0_m] -1.234
+[037_02_dph_a] 1.234
+[037_02_dph_m] 1.234
+=== measurement ===
+[037_03_measure] 1
+[037_03_x] 70.5
+[037_03_y] 64
+== calibration ==
+[037_03_cal-mode] DO
+[037_03_temp-comp] 1
+[037_03_temp_min] 10
+[037_03_temp_max] 90
+[037_03_k0_m] -0.123
+[037_03_k0_a] 12.3456
+[037_03_k100_m] -0.123
+[037_03_k100_a] 12.345
+=== measurement ===
+[037_04_measure] 1
+[037_04_x] 68
+[037_04_y] 61.5
+== calibration ==
+[037_04_cal-mode] NONE
+=== measurement ===
+[037_05_measure] 1
+[037_05_x] 68
+[037_05_y] 61.5
+== calibration ==
+[037_05_cal-mode] NONE
+===== fermentation =====
+[038_well] E06
+[038_content] X38
+[038_description]
+[038_s_vol] 0
+==== measurements ====
+=== measurement ===
+[038_01_measure] 1
+[038_01_x] 81
+[038_01_y] 61.5
+== calibration ==
+[038_01_cal-mode] NONE
+=== measurement ===
+[038_02_measure] 1
+[038_02_x] 83.5
+[038_02_y] 59
+== calibration ==
+[038_02_cal-mode] PH
+[038_02_temp-comp] 1
+[038_02_temp_min] 10
+[038_02_temp_max] 90
+[038_02_fmin_a] 12.34
+[038_02_fmin_m] -1.23
+[038_02_fmax_a] 12.34
+[038_02_fmax_m] -1.23
+[038_02_ph0_a] 1.234
+[038_02_ph0_m] -1.234
+[038_02_dph_a] 1.234
+[038_02_dph_m] 1.234
+=== measurement ===
+[038_03_measure] 1
+[038_03_x] 83.5
+[038_03_y] 64
+== calibration ==
+[038_03_cal-mode] DO
+[038_03_temp-comp] 1
+[038_03_temp_min] 10
+[038_03_temp_max] 90
+[038_03_k0_m] -0.123
+[038_03_k0_a] 12.3456
+[038_03_k100_m] -0.123
+[038_03_k100_a] 12.345
+=== measurement ===
+[038_04_measure] 1
+[038_04_x] 81
+[038_04_y] 61.5
+== calibration ==
+[038_04_cal-mode] NONE
+=== measurement ===
+[038_05_measure] 1
+[038_05_x] 81
+[038_05_y] 61.5
+== calibration ==
+[038_05_cal-mode] NONE
+===== fermentation =====
+[039_well] E07
+[039_content] X39
+[039_description]
+[039_s_vol] 0
+==== measurements ====
+=== measurement ===
+[039_01_measure] 1
+[039_01_x] 94
+[039_01_y] 61.5
+== calibration ==
+[039_01_cal-mode] NONE
+=== measurement ===
+[039_02_measure] 1
+[039_02_x] 96.5
+[039_02_y] 59
+== calibration ==
+[039_02_cal-mode] PH
+[039_02_temp-comp] 1
+[039_02_temp_min] 10
+[039_02_temp_max] 90
+[039_02_fmin_a] 12.34
+[039_02_fmin_m] -1.23
+[039_02_fmax_a] 12.34
+[039_02_fmax_m] -1.23
+[039_02_ph0_a] 1.234
+[039_02_ph0_m] -1.234
+[039_02_dph_a] 1.234
+[039_02_dph_m] 1.234
+=== measurement ===
+[039_03_measure] 1
+[039_03_x] 96.5
+[039_03_y] 64
+== calibration ==
+[039_03_cal-mode] DO
+[039_03_temp-comp] 1
+[039_03_temp_min] 10
+[039_03_temp_max] 90
+[039_03_k0_m] -0.123
+[039_03_k0_a] 12.3456
+[039_03_k100_m] -0.123
+[039_03_k100_a] 12.345
+=== measurement ===
+[039_04_measure] 1
+[039_04_x] 94
+[039_04_y] 61.5
+== calibration ==
+[039_04_cal-mode] NONE
+=== measurement ===
+[039_05_measure] 1
+[039_05_x] 94
+[039_05_y] 61.5
+== calibration ==
+[039_05_cal-mode] NONE
+===== fermentation =====
+[040_well] E08
+[040_content] X40
+[040_description]
+[040_s_vol] 0
+==== measurements ====
+=== measurement ===
+[040_01_measure] 1
+[040_01_x] 107
+[040_01_y] 61.5
+== calibration ==
+[040_01_cal-mode] NONE
+=== measurement ===
+[040_02_measure] 1
+[040_02_x] 109.5
+[040_02_y] 59
+== calibration ==
+[040_02_cal-mode] PH
+[040_02_temp-comp] 1
+[040_02_temp_min] 10
+[040_02_temp_max] 90
+[040_02_fmin_a] 12.34
+[040_02_fmin_m] -1.23
+[040_02_fmax_a] 12.34
+[040_02_fmax_m] -1.23
+[040_02_ph0_a] 1.234
+[040_02_ph0_m] -1.234
+[040_02_dph_a] 1.234
+[040_02_dph_m] 1.234
+=== measurement ===
+[040_03_measure] 1
+[040_03_x] 109.5
+[040_03_y] 64
+== calibration ==
+[040_03_cal-mode] DO
+[040_03_temp-comp] 1
+[040_03_temp_min] 10
+[040_03_temp_max] 90
+[040_03_k0_m] -0.123
+[040_03_k0_a] 12.3456
+[040_03_k100_m] -0.123
+[040_03_k100_a] 12.345
+=== measurement ===
+[040_04_measure] 1
+[040_04_x] 107
+[040_04_y] 61.5
+== calibration ==
+[040_04_cal-mode] NONE
+=== measurement ===
+[040_05_measure] 1
+[040_05_x] 107
+[040_05_y] 61.5
+== calibration ==
+[040_05_cal-mode] NONE
+===== fermentation =====
+[041_well] F08
+[041_content] X48
+[041_description]
+[041_s_vol] 0
+==== measurements ====
+=== measurement ===
+[041_01_measure] 1
+[041_01_x] 107
+[041_01_y] 74.5
+== calibration ==
+[041_01_cal-mode] NONE
+=== measurement ===
+[041_02_measure] 1
+[041_02_x] 109.5
+[041_02_y] 72
+== calibration ==
+[041_02_cal-mode] PH
+[041_02_temp-comp] 1
+[041_02_temp_min] 10
+[041_02_temp_max] 90
+[041_02_fmin_a] 12.34
+[041_02_fmin_m] -1.23
+[041_02_fmax_a] 12.34
+[041_02_fmax_m] -1.23
+[041_02_ph0_a] 1.234
+[041_02_ph0_m] -1.234
+[041_02_dph_a] 1.234
+[041_02_dph_m] 1.234
+=== measurement ===
+[041_03_measure] 1
+[041_03_x] 109.5
+[041_03_y] 77
+== calibration ==
+[041_03_cal-mode] DO
+[041_03_temp-comp] 1
+[041_03_temp_min] 10
+[041_03_temp_max] 90
+[041_03_k0_m] -0.123
+[041_03_k0_a] 12.3456
+[041_03_k100_m] -0.123
+[041_03_k100_a] 12.345
+=== measurement ===
+[041_04_measure] 1
+[041_04_x] 107
+[041_04_y] 74.5
+== calibration ==
+[041_04_cal-mode] NONE
+=== measurement ===
+[041_05_measure] 1
+[041_05_x] 107
+[041_05_y] 74.5
+== calibration ==
+[041_05_cal-mode] NONE
+===== fermentation =====
+[042_well] F07
+[042_content] X47
+[042_description]
+[042_s_vol] 0
+==== measurements ====
+=== measurement ===
+[042_01_measure] 1
+[042_01_x] 94
+[042_01_y] 74.5
+== calibration ==
+[042_01_cal-mode] NONE
+=== measurement ===
+[042_02_measure] 1
+[042_02_x] 96.5
+[042_02_y] 72
+== calibration ==
+[042_02_cal-mode] PH
+[042_02_temp-comp] 1
+[042_02_temp_min] 10
+[042_02_temp_max] 90
+[042_02_fmin_a] 12.34
+[042_02_fmin_m] -1.23
+[042_02_fmax_a] 12.34
+[042_02_fmax_m] -1.23
+[042_02_ph0_a] 1.234
+[042_02_ph0_m] -1.234
+[042_02_dph_a] 1.234
+[042_02_dph_m] 1.234
+=== measurement ===
+[042_03_measure] 1
+[042_03_x] 96.5
+[042_03_y] 77
+== calibration ==
+[042_03_cal-mode] DO
+[042_03_temp-comp] 1
+[042_03_temp_min] 10
+[042_03_temp_max] 90
+[042_03_k0_m] -0.123
+[042_03_k0_a] 12.3456
+[042_03_k100_m] -0.123
+[042_03_k100_a] 12.345
+=== measurement ===
+[042_04_measure] 1
+[042_04_x] 94
+[042_04_y] 74.5
+== calibration ==
+[042_04_cal-mode] NONE
+=== measurement ===
+[042_05_measure] 1
+[042_05_x] 94
+[042_05_y] 74.5
+== calibration ==
+[042_05_cal-mode] NONE
+===== fermentation =====
+[043_well] F06
+[043_content] X46
+[043_description]
+[043_s_vol] 0
+==== measurements ====
+=== measurement ===
+[043_01_measure] 1
+[043_01_x] 81
+[043_01_y] 74.5
+== calibration ==
+[043_01_cal-mode] NONE
+=== measurement ===
+[043_02_measure] 1
+[043_02_x] 83.5
+[043_02_y] 72
+== calibration ==
+[043_02_cal-mode] PH
+[043_02_temp-comp] 1
+[043_02_temp_min] 10
+[043_02_temp_max] 90
+[043_02_fmin_a] 12.34
+[043_02_fmin_m] -1.23
+[043_02_fmax_a] 12.34
+[043_02_fmax_m] -1.23
+[043_02_ph0_a] 1.234
+[043_02_ph0_m] -1.234
+[043_02_dph_a] 1.234
+[043_02_dph_m] 1.234
+=== measurement ===
+[043_03_measure] 1
+[043_03_x] 83.5
+[043_03_y] 77
+== calibration ==
+[043_03_cal-mode] DO
+[043_03_temp-comp] 1
+[043_03_temp_min] 10
+[043_03_temp_max] 90
+[043_03_k0_m] -0.123
+[043_03_k0_a] 12.3456
+[043_03_k100_m] -0.123
+[043_03_k100_a] 12.345
+=== measurement ===
+[043_04_measure] 1
+[043_04_x] 81
+[043_04_y] 74.5
+== calibration ==
+[043_04_cal-mode] NONE
+=== measurement ===
+[043_05_measure] 1
+[043_05_x] 81
+[043_05_y] 74.5
+== calibration ==
+[043_05_cal-mode] NONE
+===== fermentation =====
+[044_well] F05
+[044_content] X45
+[044_description]
+[044_s_vol] 0
+==== measurements ====
+=== measurement ===
+[044_01_measure] 1
+[044_01_x] 68
+[044_01_y] 74.5
+== calibration ==
+[044_01_cal-mode] NONE
+=== measurement ===
+[044_02_measure] 1
+[044_02_x] 70.5
+[044_02_y] 72
+== calibration ==
+[044_02_cal-mode] PH
+[044_02_temp-comp] 1
+[044_02_temp_min] 10
+[044_02_temp_max] 90
+[044_02_fmin_a] 12.34
+[044_02_fmin_m] -1.23
+[044_02_fmax_a] 12.34
+[044_02_fmax_m] -1.23
+[044_02_ph0_a] 1.234
+[044_02_ph0_m] -1.234
+[044_02_dph_a] 1.234
+[044_02_dph_m] 1.234
+=== measurement ===
+[044_03_measure] 1
+[044_03_x] 70.5
+[044_03_y] 77
+== calibration ==
+[044_03_cal-mode] DO
+[044_03_temp-comp] 1
+[044_03_temp_min] 10
+[044_03_temp_max] 90
+[044_03_k0_m] -0.123
+[044_03_k0_a] 12.3456
+[044_03_k100_m] -0.123
+[044_03_k100_a] 12.345
+=== measurement ===
+[044_04_measure] 1
+[044_04_x] 68
+[044_04_y] 74.5
+== calibration ==
+[044_04_cal-mode] NONE
+=== measurement ===
+[044_05_measure] 1
+[044_05_x] 68
+[044_05_y] 74.5
+== calibration ==
+[044_05_cal-mode] NONE
+===== fermentation =====
+[045_well] F04
+[045_content] X44
+[045_description]
+[045_s_vol] 0
+==== measurements ====
+=== measurement ===
+[045_01_measure] 1
+[045_01_x] 55
+[045_01_y] 74.5
+== calibration ==
+[045_01_cal-mode] NONE
+=== measurement ===
+[045_02_measure] 1
+[045_02_x] 57.5
+[045_02_y] 72
+== calibration ==
+[045_02_cal-mode] PH
+[045_02_temp-comp] 1
+[045_02_temp_min] 10
+[045_02_temp_max] 90
+[045_02_fmin_a] 12.34
+[045_02_fmin_m] -1.23
+[045_02_fmax_a] 12.34
+[045_02_fmax_m] -1.23
+[045_02_ph0_a] 1.234
+[045_02_ph0_m] -1.234
+[045_02_dph_a] 1.234
+[045_02_dph_m] 1.234
+=== measurement ===
+[045_03_measure] 1
+[045_03_x] 57.5
+[045_03_y] 77
+== calibration ==
+[045_03_cal-mode] DO
+[045_03_temp-comp] 1
+[045_03_temp_min] 10
+[045_03_temp_max] 90
+[045_03_k0_m] -0.123
+[045_03_k0_a] 12.3456
+[045_03_k100_m] -0.123
+[045_03_k100_a] 12.345
+=== measurement ===
+[045_04_measure] 1
+[045_04_x] 55
+[045_04_y] 74.5
+== calibration ==
+[045_04_cal-mode] NONE
+=== measurement ===
+[045_05_measure] 1
+[045_05_x] 55
+[045_05_y] 74.5
+== calibration ==
+[045_05_cal-mode] NONE
+===== fermentation =====
+[046_well] F03
+[046_content] X43
+[046_description]
+[046_s_vol] 0
+==== measurements ====
+=== measurement ===
+[046_01_measure] 1
+[046_01_x] 42
+[046_01_y] 74.5
+== calibration ==
+[046_01_cal-mode] NONE
+=== measurement ===
+[046_02_measure] 1
+[046_02_x] 44.5
+[046_02_y] 72
+== calibration ==
+[046_02_cal-mode] PH
+[046_02_temp-comp] 1
+[046_02_temp_min] 10
+[046_02_temp_max] 90
+[046_02_fmin_a] 12.34
+[046_02_fmin_m] -1.23
+[046_02_fmax_a] 12.34
+[046_02_fmax_m] -1.23
+[046_02_ph0_a] 1.234
+[046_02_ph0_m] -1.234
+[046_02_dph_a] 1.234
+[046_02_dph_m] 1.234
+=== measurement ===
+[046_03_measure] 1
+[046_03_x] 44.5
+[046_03_y] 77
+== calibration ==
+[046_03_cal-mode] DO
+[046_03_temp-comp] 1
+[046_03_temp_min] 10
+[046_03_temp_max] 90
+[046_03_k0_m] -0.123
+[046_03_k0_a] 12.3456
+[046_03_k100_m] -0.123
+[046_03_k100_a] 12.345
+=== measurement ===
+[046_04_measure] 1
+[046_04_x] 42
+[046_04_y] 74.5
+== calibration ==
+[046_04_cal-mode] NONE
+=== measurement ===
+[046_05_measure] 1
+[046_05_x] 42
+[046_05_y] 74.5
+== calibration ==
+[046_05_cal-mode] NONE
+===== fermentation =====
+[047_well] F02
+[047_content] X42
+[047_description]
+[047_s_vol] 0
+==== measurements ====
+=== measurement ===
+[047_01_measure] 1
+[047_01_x] 29
+[047_01_y] 74.5
+== calibration ==
+[047_01_cal-mode] NONE
+=== measurement ===
+[047_02_measure] 1
+[047_02_x] 31.5
+[047_02_y] 72
+== calibration ==
+[047_02_cal-mode] PH
+[047_02_temp-comp] 1
+[047_02_temp_min] 10
+[047_02_temp_max] 90
+[047_02_fmin_a] 12.34
+[047_02_fmin_m] -1.23
+[047_02_fmax_a] 12.34
+[047_02_fmax_m] -1.23
+[047_02_ph0_a] 1.234
+[047_02_ph0_m] -1.234
+[047_02_dph_a] 1.234
+[047_02_dph_m] 1.234
+=== measurement ===
+[047_03_measure] 1
+[047_03_x] 31.5
+[047_03_y] 77
+== calibration ==
+[047_03_cal-mode] DO
+[047_03_temp-comp] 1
+[047_03_temp_min] 10
+[047_03_temp_max] 90
+[047_03_k0_m] -0.123
+[047_03_k0_a] 12.3456
+[047_03_k100_m] -0.123
+[047_03_k100_a] 12.345
+=== measurement ===
+[047_04_measure] 1
+[047_04_x] 29
+[047_04_y] 74.5
+== calibration ==
+[047_04_cal-mode] NONE
+=== measurement ===
+[047_05_measure] 1
+[047_05_x] 29
+[047_05_y] 74.5
+== calibration ==
+[047_05_cal-mode] NONE
+===== fermentation =====
+[048_well] F01
+[048_content] X41
+[048_description]
+[048_s_vol] 0
+==== measurements ====
+=== measurement ===
+[048_01_measure] 1
+[048_01_x] 16
+[048_01_y] 74.5
+== calibration ==
+[048_01_cal-mode] NONE
+=== measurement ===
+[048_02_measure] 1
+[048_02_x] 18.5
+[048_02_y] 72
+== calibration ==
+[048_02_cal-mode] PH
+[048_02_temp-comp] 1
+[048_02_temp_min] 10
+[048_02_temp_max] 90
+[048_02_fmin_a] 12.34
+[048_02_fmin_m] -1.23
+[048_02_fmax_a] 12.34
+[048_02_fmax_m] -1.23
+[048_02_ph0_a] 1.234
+[048_02_ph0_m] -1.234
+[048_02_dph_a] 1.234
+[048_02_dph_m] 1.234
+=== measurement ===
+[048_03_measure] 1
+[048_03_x] 18.5
+[048_03_y] 77
+== calibration ==
+[048_03_cal-mode] DO
+[048_03_temp-comp] 1
+[048_03_temp_min] 10
+[048_03_temp_max] 90
+[048_03_k0_m] -0.123
+[048_03_k0_a] 12.3456
+[048_03_k100_m] -0.123
+[048_03_k100_a] 12.345
+=== measurement ===
+[048_04_measure] 1
+[048_04_x] 16
+[048_04_y] 74.5
+== calibration ==
+[048_04_cal-mode] NONE
+=== measurement ===
+[048_05_measure] 1
+[048_05_x] 16
+[048_05_y] 74.5
+== calibration ==
+[048_05_cal-mode] NONE
+[048_05_cal-mode] NONE
+=====data=====
+Type;Cycle;Well;Filterset;Time;Amp_1;Amp_2;AmpRef_1;AmpRef_2;Phase;Cal;T_UC_HumSensor_analog;T_LC_PT100;T_UC_PT100;O2;CO2;Humidity;Shaker;Service;User_Comment;Sys_Comment;Reservoir;MF_Volume;T_WB_heating_rod;T_144;T_180;T_181_1;T_192;P_UC_peltier;P_LC_peltier;P_WB_heating_rod;T_UC_HumSensor_digital;T_CO2;X-Pos;Y-Pos;T_LED;Ref_Int;Ref_Phase;Ref_Gain;Ch1-MP;Ch2-MF;Ch3-FA;Ch4-OP;Ch5-FB
+C;0001;;;11;;;;;;;;;;;;;;;;COVER CLOSED;;;
+C;0001;;;16;;;;;;;;;;;;;;;;START SHAKER;;;
+C;0001;;;16;;;;;;;;;;;;;;;;TEMP REGULATION ON;;;
+P;0001;;;16;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.856;-69.560;0;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;16;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.856;-69.560;0;;;;1.23;1.23;1.23;1.23;1.23;
+R;0001;;01;47;1.23;1.23;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;2005.37;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.856;-69.560;30;1.23;1.23;1.23;1.23
+M;0001;001;01;49;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;#;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.904;-70.064;32;1.23;1.23;1.23;1.23
+M;0001;002;01;50;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0001;003;01;51;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0001;004;01;53;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0001;005;01;54;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.880;-70.064;32;1.23;1.23;1.23;1.23
+M;0001;006;01;55;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0001;007;01;56;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.888;-70.064;32;1.23;1.23;1.23;1.23
+M;0001;008;01;58;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-70.064;32;1.23;1.23;1.23;1.23
+M;0001;009;01;59;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-57.088;32;1.23;1.23;1.23;1.23
+M;0001;010;01;60;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.872;-57.088;32;1.23;1.23;1.23;1.23
+M;0001;011;01;62;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-57.088;32;1.23;1.23;1.23;1.23
+M;0001;012;01;63;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-57.088;32;1.23;1.23;1.23;1.23
+M;0001;013;01;64;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-57.088;32;1.23;1.23;1.23;1.23
+M;0001;014;01;65;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-57.088;32;1.23;1.23;1.23;1.23
+M;0001;015;01;67;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-57.088;32;1.23;1.23;1.23;1.23
+M;0001;016;01;68;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-57.088;32;1.23;1.23;1.23;1.23
+M;0001;017;01;69;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-44.088;32;1.23;1.23;1.23;1.23
+M;0001;018;01;71;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-44.088;32;1.23;1.23;1.23;1.23
+M;0001;019;01;72;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-44.088;32;1.23;1.23;1.23;1.23
+M;0001;020;01;73;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-44.088;32;1.23;1.23;1.23;1.23
+M;0001;021;01;74;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-44.088;32;1.23;1.23;1.23;1.23
+M;0001;022;01;76;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-44.088;32;1.23;1.23;1.23;1.23
+M;0001;023;01;77;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.888;-44.088;32;1.23;1.23;1.23;1.23
+M;0001;024;01;78;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-44.088;32;1.23;1.23;1.23;1.23
+M;0001;025;01;80;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-31.104;32;1.23;1.23;1.23;1.23
+M;0001;026;01;81;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-31.104;32;1.23;1.23;1.23;1.23
+M;0001;027;01;82;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-31.104;32;1.23;1.23;1.23;1.23
+M;0001;028;01;83;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-31.104;32;1.23;1.23;1.23;1.23
+M;0001;029;01;85;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-31.104;32;1.23;1.23;1.23;1.23
+M;0001;030;01;86;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-31.104;32;1.23;1.23;1.23;1.23
+M;0001;031;01;87;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-31.104;32;1.23;1.23;1.23;1.23
+M;0001;032;01;88;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-31.104;32;1.23;1.23;1.23;1.23
+M;0001;033;01;90;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-18.104;32;1.23;1.23;1.23;1.23
+M;0001;034;01;91;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-18.104;32;1.23;1.23;1.23;1.23
+M;0001;035;01;92;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-18.104;32;1.23;1.23;1.23;1.23
+M;0001;036;01;93;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-18.104;32;1.23;1.23;1.23;1.23
+M;0001;037;01;95;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-18.104;32;1.23;1.23;1.23;1.23
+M;0001;038;01;96;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-18.104;32;1.23;1.23;1.23;1.23
+M;0001;039;01;97;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.888;-18.104;32;1.23;1.23;1.23;1.23
+M;0001;040;01;99;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-18.104;32;1.23;1.23;1.23;1.23
+M;0001;041;01;100;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-5.128;32;1.23;1.23;1.23;1.23
+M;0001;042;01;101;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-5.128;32;1.23;1.23;1.23;1.23
+M;0001;043;01;102;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-5.128;32;1.23;1.23;1.23;1.23
+M;0001;044;01;104;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.856;-5.128;32;1.23;1.23;1.23;1.23
+M;0001;045;01;105;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-5.120;32;1.23;1.23;1.23;1.23
+M;0001;046;01;106;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-5.120;32;1.23;1.23;1.23;1.23
+M;0001;047;01;108;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-5.120;32;1.23;1.23;1.23;1.23
+M;0001;048;01;109;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.120;32;1.23;1.23;1.23;1.23
+P;0001;;;109;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.120;32;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;111;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.120;2;;;;1.23;1.23;1.23;1.23;1.23;
+M;0001;001;02;133;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.400;-72.552;23;1.23;1.23;1.23;1.23
+M;0001;002;02;134;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.384;-72.552;23;1.23;1.23;1.23;1.23
+M;0001;003;02;135;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-72.552;23;1.23;1.23;1.23;1.23
+M;0001;004;02;137;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0001;005;02;138;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0001;006;02;139;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.400;-72.552;23;1.23;1.23;1.23;1.23
+M;0001;007;02;141;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0001;008;02;142;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-72.552;23;1.23;1.23;1.23;1.23
+M;0001;009;02;143;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-59.576;23;1.23;1.23;1.23;1.23
+M;0001;010;02;144;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-59.576;23;1.23;1.23;1.23;1.23
+M;0001;011;02;146;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-59.576;23;1.23;1.23;1.23;1.23
+M;0001;012;02;147;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-59.576;23;1.23;1.23;1.23;1.23
+M;0001;013;02;148;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-59.576;23;1.23;1.23;1.23;1.23
+M;0001;014;02;150;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-59.576;23;1.23;1.23;1.23;1.23
+M;0001;015;02;151;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-59.576;23;1.23;1.23;1.23;1.23
+M;0001;016;02;152;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-59.576;23;1.23;1.23;1.23;1.23
+M;0001;017;02;153;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-46.584;23;1.23;1.23;1.23;1.23
+M;0001;018;02;155;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-46.584;23;1.23;1.23;1.23;1.23
+M;0001;019;02;156;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-46.584;23;1.23;1.23;1.23;1.23
+M;0001;020;02;157;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-46.584;23;1.23;1.23;1.23;1.23
+M;0001;021;02;159;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-46.584;23;1.23;1.23;1.23;1.23
+M;0001;022;02;160;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.400;-46.584;23;1.23;1.23;1.23;1.23
+M;0001;023;02;161;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-46.584;23;1.23;1.23;1.23;1.23
+M;0001;024;02;162;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-46.584;23;1.23;1.23;1.23;1.23
+M;0001;025;02;164;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-33.600;23;1.23;1.23;1.23;1.23
+M;0001;026;02;165;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0001;027;02;166;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-33.600;23;1.23;1.23;1.23;1.23
+M;0001;028;02;168;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0001;029;02;169;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0001;030;02;170;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0001;031;02;171;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-33.600;23;1.23;1.23;1.23;1.23
+M;0001;032;02;173;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0001;033;02;174;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-20.600;23;1.23;1.23;1.23;1.23
+M;0001;034;02;175;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-20.600;23;1.23;1.23;1.23;1.23
+M;0001;035;02;176;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-20.600;23;1.23;1.23;1.23;1.23
+M;0001;036;02;178;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-20.600;23;1.23;1.23;1.23;1.23
+M;0001;037;02;179;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-20.600;23;1.23;1.23;1.23;1.23
+M;0001;038;02;180;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-20.600;23;1.23;1.23;1.23;1.23
+M;0001;039;02;182;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-20.600;23;1.23;1.23;1.23;1.23
+M;0001;040;02;183;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-20.592;23;1.23;1.23;1.23;1.23
+M;0001;041;02;184;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-7.616;23;1.23;1.23;1.23;1.23
+M;0001;042;02;185;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-7.616;23;1.23;1.23;1.23;1.23
+M;0001;043;02;187;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-7.616;23;1.23;1.23;1.23;1.23
+M;0001;044;02;188;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-7.616;23;1.23;1.23;1.23;1.23
+M;0001;045;02;189;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-7.616;23;1.23;1.23;1.23;1.23
+M;0001;046;02;191;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-7.616;23;1.23;1.23;1.23;1.23
+M;0001;047;02;192;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.352;-7.616;23;1.23;1.23;1.23;1.23
+M;0001;048;02;193;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-7.616;23;1.23;1.23;1.23;1.23
+P;0001;;;193;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-7.616;23;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;194;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-7.616;1;;;;1.23;1.23;1.23;1.23;1.23;
+M;0001;001;03;217;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0001;002;03;218;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-67.584;23;1.23;1.23;1.23;1.23
+M;0001;003;03;219;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0001;004;03;220;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.392;-67.584;23;1.23;1.23;1.23;1.23
+M;0001;005;03;222;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-67.584;23;1.23;1.23;1.23;1.23
+M;0001;006;03;223;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0001;007;03;224;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-67.584;23;1.23;1.23;1.23;1.23
+M;0001;008;03;225;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0001;009;03;227;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-54.584;23;1.23;1.23;1.23;1.23
+M;0001;010;03;228;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0001;011;03;229;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-54.576;23;1.23;1.23;1.23;1.23
+M;0001;012;03;230;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0001;013;03;232;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0001;014;03;233;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0001;015;03;234;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-54.576;23;1.23;1.23;1.23;1.23
+M;0001;016;03;236;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0001;017;03;237;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-41.584;23;1.23;1.23;1.23;1.23
+M;0001;018;03;238;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-41.584;23;1.23;1.23;1.23;1.23
+M;0001;019;03;240;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-41.584;23;1.23;1.23;1.23;1.23
+M;0001;020;03;241;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-41.584;23;1.23;1.23;1.23;1.23
+M;0001;021;03;242;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-41.584;23;1.23;1.23;1.23;1.23
+M;0001;022;03;243;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-41.584;23;1.23;1.23;1.23;1.23
+M;0001;023;03;245;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-41.584;23;1.23;1.23;1.23;1.23
+M;0001;024;03;246;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-41.584;23;1.23;1.23;1.23;1.23
+M;0001;025;03;247;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-28.592;23;1.23;1.23;1.23;1.23
+M;0001;026;03;249;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-28.592;23;1.23;1.23;1.23;1.23
+M;0001;027;03;250;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-28.592;23;1.23;1.23;1.23;1.23
+M;0001;028;03;251;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-28.592;23;1.23;1.23;1.23;1.23
+M;0001;029;03;252;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-28.592;23;1.23;1.23;1.23;1.23
+M;0001;030;03;254;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-28.592;23;1.23;1.23;1.23;1.23
+M;0001;031;03;255;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-28.592;23;1.23;1.23;1.23;1.23
+M;0001;032;03;256;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-28.592;23;1.23;1.23;1.23;1.23
+M;0001;033;03;258;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-15.608;23;1.23;1.23;1.23;1.23
+M;0001;034;03;259;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-15.608;23;1.23;1.23;1.23;1.23
+M;0001;035;03;260;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-15.608;23;1.23;1.23;1.23;1.23
+M;0001;036;03;261;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-15.608;23;1.23;1.23;1.23;1.23
+M;0001;037;03;263;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-15.608;23;1.23;1.23;1.23;1.23
+M;0001;038;03;264;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-15.608;23;1.23;1.23;1.23;1.23
+M;0001;039;03;265;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-15.608;23;1.23;1.23;1.23;1.23
+M;0001;040;03;267;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-15.608;23;1.23;1.23;1.23;1.23
+M;0001;041;03;268;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-2.616;23;1.23;1.23;1.23;1.23
+M;0001;042;03;269;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-2.616;23;1.23;1.23;1.23;1.23
+M;0001;043;03;270;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-2.616;23;1.23;1.23;1.23;1.23
+M;0001;044;03;272;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-2.616;23;1.23;1.23;1.23;1.23
+M;0001;045;03;273;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-2.616;23;1.23;1.23;1.23;1.23
+M;0001;046;03;274;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-2.616;23;1.23;1.23;1.23;1.23
+M;0001;047;03;275;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.352;-2.616;23;1.23;1.23;1.23;1.23
+M;0001;048;03;277;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-2.616;23;1.23;1.23;1.23;1.23
+P;0001;;;277;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-2.616;23;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;280;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-2.616;3;;;;1.23;1.23;1.23;1.23;1.23;
+R;0001;;04;309;1.23;1.23;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1926.60;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;32;1.23;1.23;1.23;1.23
+M;0001;001;04;311;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;#;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.904;-70.064;33;1.23;1.23;1.23;1.23
+M;0001;002;04;312;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-70.064;33;1.23;1.23;1.23;1.23
+M;0001;003;04;314;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-70.064;33;1.23;1.23;1.23;1.23
+M;0001;004;04;315;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-70.064;33;1.23;1.23;1.23;1.23
+M;0001;005;04;316;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.880;-70.064;33;1.23;1.23;1.23;1.23
+M;0001;006;04;318;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-70.064;33;1.23;1.23;1.23;1.23
+M;0001;007;04;319;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.888;-70.064;33;1.23;1.23;1.23;1.23
+M;0001;008;04;320;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-70.064;33;1.23;1.23;1.23;1.23
+M;0001;009;04;321;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-57.080;33;1.23;1.23;1.23;1.23
+M;0001;010;04;323;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-57.080;33;1.23;1.23;1.23;1.23
+M;0001;011;04;324;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-57.080;33;1.23;1.23;1.23;1.23
+M;0001;012;04;325;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-57.080;33;1.23;1.23;1.23;1.23
+M;0001;013;04;327;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-57.080;33;1.23;1.23;1.23;1.23
+M;0001;014;04;328;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-57.080;33;1.23;1.23;1.23;1.23
+M;0001;015;04;329;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-57.080;33;1.23;1.23;1.23;1.23
+M;0001;016;04;330;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-57.080;33;1.23;1.23;1.23;1.23
+M;0001;017;04;332;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-44.096;33;1.23;1.23;1.23;1.23
+M;0001;018;04;333;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0001;019;04;334;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0001;020;04;335;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-44.088;33;1.23;1.23;1.23;1.23
+M;0001;021;04;337;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-44.096;33;1.23;1.23;1.23;1.23
+M;0001;022;04;338;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-44.088;33;1.23;1.23;1.23;1.23
+M;0001;023;04;339;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-44.088;33;1.23;1.23;1.23;1.23
+M;0001;024;04;341;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0001;025;04;342;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-31.104;33;1.23;1.23;1.23;1.23
+M;0001;026;04;343;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0001;027;04;344;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-31.104;33;1.23;1.23;1.23;1.23
+M;0001;028;04;346;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0001;029;04;347;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-31.104;33;1.23;1.23;1.23;1.23
+M;0001;030;04;348;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0001;031;04;349;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0001;032;04;351;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-31.104;33;1.23;1.23;1.23;1.23
+M;0001;033;04;352;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-18.104;33;1.23;1.23;1.23;1.23
+M;0001;034;04;353;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0001;035;04;355;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0001;036;04;356;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0001;037;04;357;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-18.104;33;1.23;1.23;1.23;1.23
+M;0001;038;04;359;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0001;039;04;360;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0001;040;04;361;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0001;041;04;362;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-5.128;33;1.23;1.23;1.23;1.23
+M;0001;042;04;364;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-5.128;33;1.23;1.23;1.23;1.23
+M;0001;043;04;365;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-5.128;33;1.23;1.23;1.23;1.23
+M;0001;044;04;366;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.856;-5.128;33;1.23;1.23;1.23;1.23
+M;0001;045;04;368;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.864;-5.120;33;1.23;1.23;1.23;1.23
+M;0001;046;04;369;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-5.120;33;1.23;1.23;1.23;1.23
+M;0001;047;04;370;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-5.120;33;1.23;1.23;1.23;1.23
+M;0001;048;04;371;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.864;-5.120;33;1.23;1.23;1.23;1.23
+P;0001;;;371;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.864;-5.120;33;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;375;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.120;4;;;;1.23;1.23;1.23;1.23;1.23;
+R;0001;;05;384;1.23;1.23;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1997.79;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;12;1.23;1.23;1.23;1.23
+M;0001;001;05;385;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;#;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.904;-70.064;13;1.23;1.23;1.23;1.23
+M;0001;002;05;387;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0001;003;05;388;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0001;004;05;389;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0001;005;05;390;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-70.064;13;1.23;1.23;1.23;1.23
+M;0001;006;05;392;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0001;007;05;393;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0001;008;05;394;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0001;009;05;396;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-57.088;13;1.23;1.23;1.23;1.23
+M;0001;010;05;397;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-57.088;13;1.23;1.23;1.23;1.23
+M;0001;011;05;398;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-57.088;13;1.23;1.23;1.23;1.23
+M;0001;012;05;399;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-57.088;13;1.23;1.23;1.23;1.23
+M;0001;013;05;401;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-57.088;13;1.23;1.23;1.23;1.23
+M;0001;014;05;402;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-57.088;13;1.23;1.23;1.23;1.23
+M;0001;015;05;403;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-57.088;13;1.23;1.23;1.23;1.23
+M;0001;016;05;405;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-57.088;13;1.23;1.23;1.23;1.23
+M;0001;017;05;406;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-44.096;13;1.23;1.23;1.23;1.23
+M;0001;018;05;407;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0001;019;05;409;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0001;020;05;410;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0001;021;05;411;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-44.096;13;1.23;1.23;1.23;1.23
+M;0001;022;05;412;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0001;023;05;414;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0001;024;05;415;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0001;025;05;416;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-31.112;13;1.23;1.23;1.23;1.23
+M;0001;026;05;417;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-31.112;13;1.23;1.23;1.23;1.23
+M;0001;027;05;419;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-31.112;13;1.23;1.23;1.23;1.23
+M;0001;028;05;420;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-31.112;13;1.23;1.23;1.23;1.23
+M;0001;029;05;421;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-31.112;13;1.23;1.23;1.23;1.23
+M;0001;030;05;423;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-31.112;13;1.23;1.23;1.23;1.23
+M;0001;031;05;424;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-31.104;13;1.23;1.23;1.23;1.23
+M;0001;032;05;425;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-31.104;13;1.23;1.23;1.23;1.23
+M;0001;033;05;427;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-18.096;13;1.23;1.23;1.23;1.23
+M;0001;034;05;428;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0001;035;05;429;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0001;036;05;431;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0001;037;05;432;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-18.096;13;1.23;1.23;1.23;1.23
+M;0001;038;05;433;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0001;039;05;434;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0001;040;05;436;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0001;041;05;437;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-5.128;13;1.23;1.23;1.23;1.23
+M;0001;042;05;438;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-5.128;13;1.23;1.23;1.23;1.23
+M;0001;043;05;439;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-5.120;13;1.23;1.23;1.23;1.23
+M;0001;044;05;441;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-5.120;13;1.23;1.23;1.23;1.23
+M;0001;045;05;442;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-5.120;13;1.23;1.23;1.23;1.23
+M;0001;046;05;443;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-5.120;13;1.23;1.23;1.23;1.23
+M;0001;047;05;445;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-5.120;13;1.23;1.23;1.23;1.23
+M;0001;048;05;446;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.864;-5.120;13;1.23;1.23;1.23;1.23
+P;0001;;;446;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.864;-5.120;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;481;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;511;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;541;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;571;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;601;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;631;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;661;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;691;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;721;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;751;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;781;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;811;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;841;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;871;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0001;;;901;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+F;0001;001;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;002;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;003;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;004;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;005;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;006;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;007;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;008;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;009;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;010;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;011;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;012;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;013;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;014;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;015;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;016;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;017;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;018;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;019;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;020;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;021;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;022;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;023;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;024;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;025;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;026;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;027;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;028;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;029;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;030;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;031;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;032;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;033;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;034;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;035;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;036;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;037;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;038;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;039;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;040;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;041;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;042;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;043;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;044;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;045;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;046;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;047;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+F;0001;048;;916;;;;;;;;;;;;;;;;;-1;1000.000;1.23;1.23
+P;0002;;;916;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;919;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;3;;;;1.23;1.23;1.23;1.23;1.23;
+R;0002;;01;947;1.23;1.23;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1923.43;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;30;1.23;1.23;1.23;1.23
+M;0002;001;01;948;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;#;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.912;-70.064;32;1.23;1.23;1.23;1.23
+M;0002;002;01;950;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0002;003;01;951;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0002;004;01;952;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0002;005;01;954;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-70.064;32;1.23;1.23;1.23;1.23
+M;0002;006;01;955;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0002;007;01;956;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0002;008;01;957;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0002;009;01;959;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-57.080;32;1.23;1.23;1.23;1.23
+M;0002;010;01;960;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-57.080;32;1.23;1.23;1.23;1.23
+M;0002;011;01;961;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-57.080;32;1.23;1.23;1.23;1.23
+M;0002;012;01;963;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-57.080;32;1.23;1.23;1.23;1.23
+M;0002;013;01;964;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-57.080;32;1.23;1.23;1.23;1.23
+M;0002;014;01;965;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-57.080;32;1.23;1.23;1.23;1.23
+M;0002;015;01;966;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-57.080;32;1.23;1.23;1.23;1.23
+M;0002;016;01;968;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-57.080;32;1.23;1.23;1.23;1.23
+M;0002;017;01;969;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-44.096;32;1.23;1.23;1.23;1.23
+M;0002;018;01;970;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0002;019;01;972;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0002;020;01;973;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0002;021;01;974;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-44.096;32;1.23;1.23;1.23;1.23
+M;0002;022;01;976;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0002;023;01;977;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.888;-44.096;32;1.23;1.23;1.23;1.23
+M;0002;024;01;978;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0002;025;01;979;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-31.112;32;1.23;1.23;1.23;1.23
+M;0002;026;01;981;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-31.112;32;1.23;1.23;1.23;1.23
+M;0002;027;01;982;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-31.112;32;1.23;1.23;1.23;1.23
+M;0002;028;01;983;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-31.112;32;1.23;1.23;1.23;1.23
+M;0002;029;01;984;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-31.112;32;1.23;1.23;1.23;1.23
+M;0002;030;01;986;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-31.112;32;1.23;1.23;1.23;1.23
+M;0002;031;01;987;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-31.112;32;1.23;1.23;1.23;1.23
+M;0002;032;01;988;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-31.112;32;1.23;1.23;1.23;1.23
+M;0002;033;01;990;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-18.104;32;1.23;1.23;1.23;1.23
+M;0002;034;01;991;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-18.104;32;1.23;1.23;1.23;1.23
+M;0002;035;01;992;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-18.104;32;1.23;1.23;1.23;1.23
+M;0002;036;01;994;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-18.104;32;1.23;1.23;1.23;1.23
+M;0002;037;01;995;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-18.104;32;1.23;1.23;1.23;1.23
+M;0002;038;01;996;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-18.104;32;1.23;1.23;1.23;1.23
+M;0002;039;01;997;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-18.104;32;1.23;1.23;1.23;1.23
+M;0002;040;01;999;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-18.104;32;1.23;1.23;1.23;1.23
+M;0002;041;01;1000;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-5.128;32;1.23;1.23;1.23;1.23
+M;0002;042;01;1001;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-5.128;32;1.23;1.23;1.23;1.23
+M;0002;043;01;1003;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-5.128;32;1.23;1.23;1.23;1.23
+M;0002;044;01;1004;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-5.128;32;1.23;1.23;1.23;1.23
+M;0002;045;01;1005;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-5.128;32;1.23;1.23;1.23;1.23
+M;0002;046;01;1006;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-5.128;32;1.23;1.23;1.23;1.23
+M;0002;047;01;1008;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-5.128;32;1.23;1.23;1.23;1.23
+M;0002;048;01;1009;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.128;32;1.23;1.23;1.23;1.23
+P;0002;;;1009;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.128;32;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1011;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.128;2;;;;1.23;1.23;1.23;1.23;1.23;
+M;0002;001;02;1033;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.408;-72.552;23;1.23;1.23;1.23;1.23
+M;0002;002;02;1034;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0002;003;02;1035;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-72.552;23;1.23;1.23;1.23;1.23
+M;0002;004;02;1036;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0002;005;02;1038;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0002;006;02;1039;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.400;-72.552;23;1.23;1.23;1.23;1.23
+M;0002;007;02;1040;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0002;008;02;1041;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-72.552;23;1.23;1.23;1.23;1.23
+M;0002;009;02;1043;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-59.584;23;1.23;1.23;1.23;1.23
+M;0002;010;02;1044;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-59.584;23;1.23;1.23;1.23;1.23
+M;0002;011;02;1045;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-59.584;23;1.23;1.23;1.23;1.23
+M;0002;012;02;1046;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-59.584;23;1.23;1.23;1.23;1.23
+M;0002;013;02;1048;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-59.584;23;1.23;1.23;1.23;1.23
+M;0002;014;02;1049;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-59.576;23;1.23;1.23;1.23;1.23
+M;0002;015;02;1050;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-59.576;23;1.23;1.23;1.23;1.23
+M;0002;016;02;1052;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-59.576;23;1.23;1.23;1.23;1.23
+M;0002;017;02;1053;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-46.576;23;1.23;1.23;1.23;1.23
+M;0002;018;02;1054;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-46.576;23;1.23;1.23;1.23;1.23
+M;0002;019;02;1055;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-46.576;23;1.23;1.23;1.23;1.23
+M;0002;020;02;1057;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-46.576;23;1.23;1.23;1.23;1.23
+M;0002;021;02;1058;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-46.576;23;1.23;1.23;1.23;1.23
+M;0002;022;02;1059;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-46.576;23;1.23;1.23;1.23;1.23
+M;0002;023;02;1061;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-46.576;23;1.23;1.23;1.23;1.23
+M;0002;024;02;1062;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-46.576;23;1.23;1.23;1.23;1.23
+M;0002;025;02;1063;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-33.600;23;1.23;1.23;1.23;1.23
+M;0002;026;02;1064;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0002;027;02;1066;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-33.600;23;1.23;1.23;1.23;1.23
+M;0002;028;02;1067;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0002;029;02;1068;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0002;030;02;1069;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0002;031;02;1071;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-33.600;23;1.23;1.23;1.23;1.23
+M;0002;032;02;1072;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0002;033;02;1073;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-20.600;23;1.23;1.23;1.23;1.23
+M;0002;034;02;1075;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-20.592;23;1.23;1.23;1.23;1.23
+M;0002;035;02;1076;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-20.592;23;1.23;1.23;1.23;1.23
+M;0002;036;02;1077;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-20.592;23;1.23;1.23;1.23;1.23
+M;0002;037;02;1078;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-20.592;23;1.23;1.23;1.23;1.23
+M;0002;038;02;1080;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-20.592;23;1.23;1.23;1.23;1.23
+M;0002;039;02;1081;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.400;-20.592;23;1.23;1.23;1.23;1.23
+M;0002;040;02;1082;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-20.592;23;1.23;1.23;1.23;1.23
+M;0002;041;02;1084;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-7.624;23;1.23;1.23;1.23;1.23
+M;0002;042;02;1085;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-7.624;23;1.23;1.23;1.23;1.23
+M;0002;043;02;1086;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-7.624;23;1.23;1.23;1.23;1.23
+M;0002;044;02;1087;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-7.624;23;1.23;1.23;1.23;1.23
+M;0002;045;02;1089;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-7.624;23;1.23;1.23;1.23;1.23
+M;0002;046;02;1090;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-7.624;23;1.23;1.23;1.23;1.23
+M;0002;047;02;1091;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-7.624;23;1.23;1.23;1.23;1.23
+M;0002;048;02;1093;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-7.624;23;1.23;1.23;1.23;1.23
+P;0002;;;1093;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-7.624;23;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1094;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-7.624;1;;;;1.23;1.23;1.23;1.23;1.23;
+M;0002;001;03;1116;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.408;-67.584;23;1.23;1.23;1.23;1.23
+M;0002;002;03;1118;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-67.584;23;1.23;1.23;1.23;1.23
+M;0002;003;03;1119;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0002;004;03;1120;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0002;005;03;1122;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-67.584;23;1.23;1.23;1.23;1.23
+M;0002;006;03;1123;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0002;007;03;1124;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0002;008;03;1125;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0002;009;03;1127;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-54.576;23;1.23;1.23;1.23;1.23
+M;0002;010;03;1128;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0002;011;03;1129;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-54.576;23;1.23;1.23;1.23;1.23
+M;0002;012;03;1131;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0002;013;03;1132;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0002;014;03;1133;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0002;015;03;1134;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-54.576;23;1.23;1.23;1.23;1.23
+M;0002;016;03;1136;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0002;017;03;1137;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-41.584;23;1.23;1.23;1.23;1.23
+M;0002;018;03;1138;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-41.584;23;1.23;1.23;1.23;1.23
+M;0002;019;03;1140;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-41.584;23;1.23;1.23;1.23;1.23
+M;0002;020;03;1141;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-41.584;23;1.23;1.23;1.23;1.23
+M;0002;021;03;1142;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-41.584;23;1.23;1.23;1.23;1.23
+M;0002;022;03;1143;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-41.584;23;1.23;1.23;1.23;1.23
+M;0002;023;03;1145;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-41.576;23;1.23;1.23;1.23;1.23
+M;0002;024;03;1146;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-41.576;23;1.23;1.23;1.23;1.23
+M;0002;025;03;1147;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-28.600;23;1.23;1.23;1.23;1.23
+M;0002;026;03;1149;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0002;027;03;1150;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-28.600;23;1.23;1.23;1.23;1.23
+M;0002;028;03;1151;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0002;029;03;1152;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0002;030;03;1154;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0002;031;03;1155;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-28.600;23;1.23;1.23;1.23;1.23
+M;0002;032;03;1156;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0002;033;03;1158;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-15.608;23;1.23;1.23;1.23;1.23
+M;0002;034;03;1159;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-15.608;23;1.23;1.23;1.23;1.23
+M;0002;035;03;1160;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-15.608;23;1.23;1.23;1.23;1.23
+M;0002;036;03;1162;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-15.608;23;1.23;1.23;1.23;1.23
+M;0002;037;03;1163;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-15.608;23;1.23;1.23;1.23;1.23
+M;0002;038;03;1164;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-15.608;23;1.23;1.23;1.23;1.23
+M;0002;039;03;1165;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.400;-15.608;23;1.23;1.23;1.23;1.23
+M;0002;040;03;1167;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-15.608;23;1.23;1.23;1.23;1.23
+M;0002;041;03;1168;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-2.616;23;1.23;1.23;1.23;1.23
+M;0002;042;03;1169;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-2.624;23;1.23;1.23;1.23;1.23
+M;0002;043;03;1171;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-2.624;23;1.23;1.23;1.23;1.23
+M;0002;044;03;1172;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-2.624;23;1.23;1.23;1.23;1.23
+M;0002;045;03;1173;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-2.624;23;1.23;1.23;1.23;1.23
+M;0002;046;03;1174;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-2.624;23;1.23;1.23;1.23;1.23
+M;0002;047;03;1176;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.352;-2.624;23;1.23;1.23;1.23;1.23
+M;0002;048;03;1177;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-2.624;23;1.23;1.23;1.23;1.23
+P;0002;;;1177;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-2.624;23;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1180;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-2.624;3;;;;1.23;1.23;1.23;1.23;1.23;
+R;0002;;04;1210;1.23;1.23;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1920.46;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;32;1.23;1.23;1.23;1.23
+M;0002;001;04;1211;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;#;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.904;-70.056;33;1.23;1.23;1.23;1.23
+M;0002;002;04;1212;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-70.056;33;1.23;1.23;1.23;1.23
+M;0002;003;04;1214;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-70.056;33;1.23;1.23;1.23;1.23
+M;0002;004;04;1215;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-70.056;33;1.23;1.23;1.23;1.23
+M;0002;005;04;1216;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.880;-70.056;33;1.23;1.23;1.23;1.23
+M;0002;006;04;1218;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-70.056;33;1.23;1.23;1.23;1.23
+M;0002;007;04;1219;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.888;-70.056;33;1.23;1.23;1.23;1.23
+M;0002;008;04;1220;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-70.056;33;1.23;1.23;1.23;1.23
+M;0002;009;04;1221;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-57.088;33;1.23;1.23;1.23;1.23
+M;0002;010;04;1223;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-57.080;33;1.23;1.23;1.23;1.23
+M;0002;011;04;1224;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-57.080;33;1.23;1.23;1.23;1.23
+M;0002;012;04;1225;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-57.080;33;1.23;1.23;1.23;1.23
+M;0002;013;04;1227;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-57.080;33;1.23;1.23;1.23;1.23
+M;0002;014;04;1228;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-57.080;33;1.23;1.23;1.23;1.23
+M;0002;015;04;1229;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-57.080;33;1.23;1.23;1.23;1.23
+M;0002;016;04;1230;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-57.080;33;1.23;1.23;1.23;1.23
+M;0002;017;04;1232;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-44.096;33;1.23;1.23;1.23;1.23
+M;0002;018;04;1233;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0002;019;04;1234;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0002;020;04;1236;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0002;021;04;1237;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-44.096;33;1.23;1.23;1.23;1.23
+M;0002;022;04;1238;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0002;023;04;1239;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0002;024;04;1241;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0002;025;04;1242;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-31.112;33;1.23;1.23;1.23;1.23
+M;0002;026;04;1243;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0002;027;04;1245;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-31.104;33;1.23;1.23;1.23;1.23
+M;0002;028;04;1246;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0002;029;04;1247;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-31.104;33;1.23;1.23;1.23;1.23
+M;0002;030;04;1249;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0002;031;04;1250;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0002;032;04;1251;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-31.104;33;1.23;1.23;1.23;1.23
+M;0002;033;04;1252;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-18.104;33;1.23;1.23;1.23;1.23
+M;0002;034;04;1254;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0002;035;04;1255;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0002;036;04;1256;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0002;037;04;1258;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-18.104;33;1.23;1.23;1.23;1.23
+M;0002;038;04;1259;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0002;039;04;1260;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0002;040;04;1261;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0002;041;04;1263;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-5.128;33;1.23;1.23;1.23;1.23
+M;0002;042;04;1264;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-5.128;33;1.23;1.23;1.23;1.23
+M;0002;043;04;1265;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-5.128;33;1.23;1.23;1.23;1.23
+M;0002;044;04;1267;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-5.128;33;1.23;1.23;1.23;1.23
+M;0002;045;04;1268;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-5.128;33;1.23;1.23;1.23;1.23
+M;0002;046;04;1269;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-5.120;33;1.23;1.23;1.23;1.23
+M;0002;047;04;1270;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-5.120;33;1.23;1.23;1.23;1.23
+M;0002;048;04;1272;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.120;33;1.23;1.23;1.23;1.23
+P;0002;;;1272;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.120;33;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1275;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.120;3;;;;1.23;1.23;1.23;1.23;1.23;
+R;0002;;05;1285;1.23;1.23;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1999.84;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;12;1.23;1.23;1.23;1.23
+M;0002;001;05;1286;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;#;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.912;-70.064;13;1.23;1.23;1.23;1.23
+M;0002;002;05;1287;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0002;003;05;1289;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0002;004;05;1290;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0002;005;05;1291;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-70.064;13;1.23;1.23;1.23;1.23
+M;0002;006;05;1293;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0002;007;05;1294;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.888;-70.064;13;1.23;1.23;1.23;1.23
+M;0002;008;05;1295;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0002;009;05;1296;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-57.080;13;1.23;1.23;1.23;1.23
+M;0002;010;05;1298;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-57.080;13;1.23;1.23;1.23;1.23
+M;0002;011;05;1299;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-57.080;13;1.23;1.23;1.23;1.23
+M;0002;012;05;1300;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-57.080;13;1.23;1.23;1.23;1.23
+M;0002;013;05;1302;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-57.080;13;1.23;1.23;1.23;1.23
+M;0002;014;05;1303;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-57.080;13;1.23;1.23;1.23;1.23
+M;0002;015;05;1304;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-57.080;13;1.23;1.23;1.23;1.23
+M;0002;016;05;1305;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-57.080;13;1.23;1.23;1.23;1.23
+M;0002;017;05;1307;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-44.096;13;1.23;1.23;1.23;1.23
+M;0002;018;05;1308;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0002;019;05;1309;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0002;020;05;1310;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0002;021;05;1312;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-44.096;13;1.23;1.23;1.23;1.23
+M;0002;022;05;1313;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0002;023;05;1314;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.888;-44.096;13;1.23;1.23;1.23;1.23
+M;0002;024;05;1316;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0002;025;05;1317;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-31.096;13;1.23;1.23;1.23;1.23
+M;0002;026;05;1318;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-31.104;13;1.23;1.23;1.23;1.23
+M;0002;027;05;1319;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-31.104;13;1.23;1.23;1.23;1.23
+M;0002;028;05;1321;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-31.104;13;1.23;1.23;1.23;1.23
+M;0002;029;05;1322;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-31.104;13;1.23;1.23;1.23;1.23
+M;0002;030;05;1323;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-31.104;13;1.23;1.23;1.23;1.23
+M;0002;031;05;1324;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-31.104;13;1.23;1.23;1.23;1.23
+M;0002;032;05;1326;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-31.104;13;1.23;1.23;1.23;1.23
+M;0002;033;05;1327;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-18.096;13;1.23;1.23;1.23;1.23
+M;0002;034;05;1328;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0002;035;05;1330;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0002;036;05;1331;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0002;037;05;1332;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-18.096;13;1.23;1.23;1.23;1.23
+M;0002;038;05;1333;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0002;039;05;1335;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0002;040;05;1336;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0002;041;05;1337;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-5.128;13;1.23;1.23;1.23;1.23
+M;0002;042;05;1339;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-5.128;13;1.23;1.23;1.23;1.23
+M;0002;043;05;1340;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-5.128;13;1.23;1.23;1.23;1.23
+M;0002;044;05;1341;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-5.128;13;1.23;1.23;1.23;1.23
+M;0002;045;05;1342;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-5.128;13;1.23;1.23;1.23;1.23
+M;0002;046;05;1344;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-5.128;13;1.23;1.23;1.23;1.23
+M;0002;047;05;1345;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-5.128;13;1.23;1.23;1.23;1.23
+M;0002;048;05;1346;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.128;13;1.23;1.23;1.23;1.23
+P;0002;;;1346;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.128;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1381;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1411;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1441;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1471;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1501;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1531;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1561;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1591;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1621;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1651;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1681;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1711;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1741;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1771;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0002;;;1801;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+F;0002;001;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;002;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;003;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;004;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;005;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;006;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;007;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;008;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;009;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;010;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;011;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;012;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;013;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;014;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;015;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;016;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;017;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;018;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;019;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;020;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;021;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;022;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;023;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;024;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;025;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;026;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;027;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;028;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;029;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;030;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;031;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;032;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;033;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;034;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;035;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;036;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;037;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;038;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;039;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;040;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;041;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;042;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;043;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;044;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;045;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;046;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;047;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0002;048;;1816;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+P;0003;;;1816;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;1820;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;4;;;;1.23;1.23;1.23;1.23;1.23;
+R;0003;;01;1847;1.23;1.23;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1918.06;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;30;1.23;1.23;1.23;1.23
+M;0003;001;01;1848;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;#;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.912;-70.064;32;1.23;1.23;1.23;1.23
+M;0003;002;01;1850;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0003;003;01;1851;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0003;004;01;1852;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0003;005;01;1854;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-70.064;32;1.23;1.23;1.23;1.23
+M;0003;006;01;1855;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0003;007;01;1856;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0003;008;01;1857;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0003;009;01;1859;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-57.088;32;1.23;1.23;1.23;1.23
+M;0003;010;01;1860;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-57.088;32;1.23;1.23;1.23;1.23
+M;0003;011;01;1861;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-57.088;32;1.23;1.23;1.23;1.23
+M;0003;012;01;1863;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-57.088;32;1.23;1.23;1.23;1.23
+M;0003;013;01;1864;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-57.088;32;1.23;1.23;1.23;1.23
+M;0003;014;01;1865;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-57.088;32;1.23;1.23;1.23;1.23
+M;0003;015;01;1866;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-57.088;32;1.23;1.23;1.23;1.23
+M;0003;016;01;1868;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-57.088;32;1.23;1.23;1.23;1.23
+M;0003;017;01;1869;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-44.096;32;1.23;1.23;1.23;1.23
+M;0003;018;01;1870;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0003;019;01;1872;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0003;020;01;1873;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0003;021;01;1874;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-44.096;32;1.23;1.23;1.23;1.23
+M;0003;022;01;1875;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0003;023;01;1877;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0003;024;01;1878;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0003;025;01;1879;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-31.104;32;1.23;1.23;1.23;1.23
+M;0003;026;01;1880;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-31.104;32;1.23;1.23;1.23;1.23
+M;0003;027;01;1882;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-31.104;32;1.23;1.23;1.23;1.23
+M;0003;028;01;1883;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-31.104;32;1.23;1.23;1.23;1.23
+M;0003;029;01;1884;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-31.104;32;1.23;1.23;1.23;1.23
+M;0003;030;01;1886;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-31.104;32;1.23;1.23;1.23;1.23
+M;0003;031;01;1887;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-31.104;32;1.23;1.23;1.23;1.23
+M;0003;032;01;1888;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-31.104;32;1.23;1.23;1.23;1.23
+M;0003;033;01;1889;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-18.096;32;1.23;1.23;1.23;1.23
+M;0003;034;01;1891;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-18.096;32;1.23;1.23;1.23;1.23
+M;0003;035;01;1892;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-18.096;32;1.23;1.23;1.23;1.23
+M;0003;036;01;1893;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-18.096;32;1.23;1.23;1.23;1.23
+M;0003;037;01;1895;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-18.096;32;1.23;1.23;1.23;1.23
+M;0003;038;01;1896;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-18.096;32;1.23;1.23;1.23;1.23
+M;0003;039;01;1897;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-18.096;32;1.23;1.23;1.23;1.23
+M;0003;040;01;1898;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-18.096;32;1.23;1.23;1.23;1.23
+M;0003;041;01;1900;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-5.128;32;1.23;1.23;1.23;1.23
+M;0003;042;01;1901;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-5.128;32;1.23;1.23;1.23;1.23
+M;0003;043;01;1902;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-5.128;32;1.23;1.23;1.23;1.23
+M;0003;044;01;1904;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-5.128;32;1.23;1.23;1.23;1.23
+M;0003;045;01;1905;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-5.128;32;1.23;1.23;1.23;1.23
+M;0003;046;01;1906;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-5.128;32;1.23;1.23;1.23;1.23
+M;0003;047;01;1907;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-5.128;32;1.23;1.23;1.23;1.23
+M;0003;048;01;1909;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.128;32;1.23;1.23;1.23;1.23
+P;0003;;;1909;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.128;32;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;1911;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.128;2;;;;1.23;1.23;1.23;1.23;1.23;
+M;0003;001;02;1932;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.408;-72.552;23;1.23;1.23;1.23;1.23
+M;0003;002;02;1934;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0003;003;02;1935;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-72.552;23;1.23;1.23;1.23;1.23
+M;0003;004;02;1936;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0003;005;02;1938;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0003;006;02;1939;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-72.552;23;1.23;1.23;1.23;1.23
+M;0003;007;02;1940;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0003;008;02;1941;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-72.552;23;1.23;1.23;1.23;1.23
+M;0003;009;02;1943;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-59.584;23;1.23;1.23;1.23;1.23
+M;0003;010;02;1944;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-59.584;23;1.23;1.23;1.23;1.23
+M;0003;011;02;1945;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-59.584;23;1.23;1.23;1.23;1.23
+M;0003;012;02;1947;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-59.584;23;1.23;1.23;1.23;1.23
+M;0003;013;02;1948;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-59.584;23;1.23;1.23;1.23;1.23
+M;0003;014;02;1949;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-59.584;23;1.23;1.23;1.23;1.23
+M;0003;015;02;1950;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-59.584;23;1.23;1.23;1.23;1.23
+M;0003;016;02;1952;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-59.584;23;1.23;1.23;1.23;1.23
+M;0003;017;02;1953;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-46.584;23;1.23;1.23;1.23;1.23
+M;0003;018;02;1954;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-46.584;23;1.23;1.23;1.23;1.23
+M;0003;019;02;1956;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-46.584;23;1.23;1.23;1.23;1.23
+M;0003;020;02;1957;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-46.584;23;1.23;1.23;1.23;1.23
+M;0003;021;02;1958;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-46.584;23;1.23;1.23;1.23;1.23
+M;0003;022;02;1959;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-46.584;23;1.23;1.23;1.23;1.23
+M;0003;023;02;1961;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-46.584;23;1.23;1.23;1.23;1.23
+M;0003;024;02;1962;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-46.584;23;1.23;1.23;1.23;1.23
+M;0003;025;02;1963;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-33.600;23;1.23;1.23;1.23;1.23
+M;0003;026;02;1965;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0003;027;02;1966;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-33.600;23;1.23;1.23;1.23;1.23
+M;0003;028;02;1967;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0003;029;02;1968;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0003;030;02;1970;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0003;031;02;1971;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-33.600;23;1.23;1.23;1.23;1.23
+M;0003;032;02;1972;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0003;033;02;1974;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-20.600;23;1.23;1.23;1.23;1.23
+M;0003;034;02;1975;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-20.600;23;1.23;1.23;1.23;1.23
+M;0003;035;02;1976;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-20.600;23;1.23;1.23;1.23;1.23
+M;0003;036;02;1977;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-20.600;23;1.23;1.23;1.23;1.23
+M;0003;037;02;1979;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-20.592;23;1.23;1.23;1.23;1.23
+M;0003;038;02;1980;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-20.592;23;1.23;1.23;1.23;1.23
+M;0003;039;02;1981;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.400;-20.592;23;1.23;1.23;1.23;1.23
+M;0003;040;02;1983;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-20.592;23;1.23;1.23;1.23;1.23
+M;0003;041;02;1984;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-7.616;23;1.23;1.23;1.23;1.23
+M;0003;042;02;1985;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-7.616;23;1.23;1.23;1.23;1.23
+M;0003;043;02;1986;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-7.616;23;1.23;1.23;1.23;1.23
+M;0003;044;02;1988;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-7.616;23;1.23;1.23;1.23;1.23
+M;0003;045;02;1989;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-7.616;23;1.23;1.23;1.23;1.23
+M;0003;046;02;1990;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-7.616;23;1.23;1.23;1.23;1.23
+M;0003;047;02;1991;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.352;-7.616;23;1.23;1.23;1.23;1.23
+M;0003;048;02;1993;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-7.616;23;1.23;1.23;1.23;1.23
+P;0003;;;1993;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-7.616;23;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;1994;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-7.616;1;;;;1.23;1.23;1.23;1.23;1.23;
+M;0003;001;03;2017;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.408;-67.584;23;1.23;1.23;1.23;1.23
+M;0003;002;03;2018;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-67.584;23;1.23;1.23;1.23;1.23
+M;0003;003;03;2019;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0003;004;03;2020;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0003;005;03;2022;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-67.584;23;1.23;1.23;1.23;1.23
+M;0003;006;03;2023;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0003;007;03;2024;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-67.584;23;1.23;1.23;1.23;1.23
+M;0003;008;03;2025;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0003;009;03;2027;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-54.576;23;1.23;1.23;1.23;1.23
+M;0003;010;03;2028;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0003;011;03;2029;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-54.576;23;1.23;1.23;1.23;1.23
+M;0003;012;03;2031;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0003;013;03;2032;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0003;014;03;2033;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0003;015;03;2034;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-54.576;23;1.23;1.23;1.23;1.23
+M;0003;016;03;2036;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0003;017;03;2037;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-41.584;23;1.23;1.23;1.23;1.23
+M;0003;018;03;2038;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-41.584;23;1.23;1.23;1.23;1.23
+M;0003;019;03;2040;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-41.584;23;1.23;1.23;1.23;1.23
+M;0003;020;03;2041;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-41.584;23;1.23;1.23;1.23;1.23
+M;0003;021;03;2042;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-41.584;23;1.23;1.23;1.23;1.23
+M;0003;022;03;2043;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-41.584;23;1.23;1.23;1.23;1.23
+M;0003;023;03;2045;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-41.584;23;1.23;1.23;1.23;1.23
+M;0003;024;03;2046;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-41.584;23;1.23;1.23;1.23;1.23
+M;0003;025;03;2047;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-28.600;23;1.23;1.23;1.23;1.23
+M;0003;026;03;2048;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0003;027;03;2050;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-28.600;23;1.23;1.23;1.23;1.23
+M;0003;028;03;2051;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0003;029;03;2052;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0003;030;03;2054;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0003;031;03;2055;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-28.600;23;1.23;1.23;1.23;1.23
+M;0003;032;03;2056;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0003;033;03;2057;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-15.600;23;1.23;1.23;1.23;1.23
+M;0003;034;03;2059;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-15.600;23;1.23;1.23;1.23;1.23
+M;0003;035;03;2060;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-15.600;23;1.23;1.23;1.23;1.23
+M;0003;036;03;2061;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-15.600;23;1.23;1.23;1.23;1.23
+M;0003;037;03;2062;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-15.600;23;1.23;1.23;1.23;1.23
+M;0003;038;03;2064;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-15.600;23;1.23;1.23;1.23;1.23
+M;0003;039;03;2065;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.400;-15.600;23;1.23;1.23;1.23;1.23
+M;0003;040;03;2066;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-15.600;23;1.23;1.23;1.23;1.23
+M;0003;041;03;2068;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-2.624;23;1.23;1.23;1.23;1.23
+M;0003;042;03;2069;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-2.624;23;1.23;1.23;1.23;1.23
+M;0003;043;03;2070;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-2.624;23;1.23;1.23;1.23;1.23
+M;0003;044;03;2071;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-2.624;23;1.23;1.23;1.23;1.23
+M;0003;045;03;2073;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-2.624;23;1.23;1.23;1.23;1.23
+M;0003;046;03;2074;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-2.624;23;1.23;1.23;1.23;1.23
+M;0003;047;03;2075;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.352;-2.624;23;1.23;1.23;1.23;1.23
+M;0003;048;03;2076;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-2.624;23;1.23;1.23;1.23;1.23
+P;0003;;;2076;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-2.624;23;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2079;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-2.624;3;;;;1.23;1.23;1.23;1.23;1.23;
+R;0003;;04;2108;1.23;1.23;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1914.07;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;32;1.23;1.23;1.23;1.23
+M;0003;001;04;2110;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;#;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.904;-70.064;33;1.23;1.23;1.23;1.23
+M;0003;002;04;2111;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-70.064;33;1.23;1.23;1.23;1.23
+M;0003;003;04;2113;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-70.064;33;1.23;1.23;1.23;1.23
+M;0003;004;04;2114;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-70.064;33;1.23;1.23;1.23;1.23
+M;0003;005;04;2115;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-70.064;33;1.23;1.23;1.23;1.23
+M;0003;006;04;2117;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-70.064;33;1.23;1.23;1.23;1.23
+M;0003;007;04;2118;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.888;-70.064;33;1.23;1.23;1.23;1.23
+M;0003;008;04;2119;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-70.064;33;1.23;1.23;1.23;1.23
+M;0003;009;04;2120;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-57.088;33;1.23;1.23;1.23;1.23
+M;0003;010;04;2122;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-57.088;33;1.23;1.23;1.23;1.23
+M;0003;011;04;2123;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-57.080;33;1.23;1.23;1.23;1.23
+M;0003;012;04;2124;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-57.080;33;1.23;1.23;1.23;1.23
+M;0003;013;04;2125;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-57.080;33;1.23;1.23;1.23;1.23
+M;0003;014;04;2127;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-57.080;33;1.23;1.23;1.23;1.23
+M;0003;015;04;2128;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-57.080;33;1.23;1.23;1.23;1.23
+M;0003;016;04;2129;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-57.080;33;1.23;1.23;1.23;1.23
+M;0003;017;04;2130;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-44.096;33;1.23;1.23;1.23;1.23
+M;0003;018;04;2132;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0003;019;04;2133;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0003;020;04;2134;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0003;021;04;2136;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-44.096;33;1.23;1.23;1.23;1.23
+M;0003;022;04;2137;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0003;023;04;2138;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0003;024;04;2140;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0003;025;04;2141;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-31.104;33;1.23;1.23;1.23;1.23
+M;0003;026;04;2142;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0003;027;04;2143;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-31.104;33;1.23;1.23;1.23;1.23
+M;0003;028;04;2145;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.856;-31.104;33;1.23;1.23;1.23;1.23
+M;0003;029;04;2146;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-31.104;33;1.23;1.23;1.23;1.23
+M;0003;030;04;2147;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0003;031;04;2149;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0003;032;04;2150;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-31.104;33;1.23;1.23;1.23;1.23
+M;0003;033;04;2151;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-18.104;33;1.23;1.23;1.23;1.23
+M;0003;034;04;2152;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0003;035;04;2154;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-18.096;33;1.23;1.23;1.23;1.23
+M;0003;036;04;2155;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-18.096;33;1.23;1.23;1.23;1.23
+M;0003;037;04;2156;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-18.096;33;1.23;1.23;1.23;1.23
+M;0003;038;04;2158;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-18.096;33;1.23;1.23;1.23;1.23
+M;0003;039;04;2159;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-18.096;33;1.23;1.23;1.23;1.23
+M;0003;040;04;2160;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-18.096;33;1.23;1.23;1.23;1.23
+M;0003;041;04;2161;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-5.128;33;1.23;1.23;1.23;1.23
+M;0003;042;04;2163;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-5.128;33;1.23;1.23;1.23;1.23
+M;0003;043;04;2164;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-5.120;33;1.23;1.23;1.23;1.23
+M;0003;044;04;2165;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-5.120;33;1.23;1.23;1.23;1.23
+M;0003;045;04;2167;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-5.120;33;1.23;1.23;1.23;1.23
+M;0003;046;04;2168;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-5.120;33;1.23;1.23;1.23;1.23
+M;0003;047;04;2169;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-5.120;33;1.23;1.23;1.23;1.23
+M;0003;048;04;2170;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.864;-5.120;33;1.23;1.23;1.23;1.23
+P;0003;;;2170;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.864;-5.120;33;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2174;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.120;4;;;;1.23;1.23;1.23;1.23;1.23;
+R;0003;;05;2182;1.23;1.23;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1997.18;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;12;1.23;1.23;1.23;1.23
+M;0003;001;05;2184;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;#;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.904;-70.056;13;1.23;1.23;1.23;1.23
+M;0003;002;05;2185;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-70.056;13;1.23;1.23;1.23;1.23
+M;0003;003;05;2187;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-70.056;13;1.23;1.23;1.23;1.23
+M;0003;004;05;2188;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-70.056;13;1.23;1.23;1.23;1.23
+M;0003;005;05;2189;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-70.056;13;1.23;1.23;1.23;1.23
+M;0003;006;05;2190;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-70.056;13;1.23;1.23;1.23;1.23
+M;0003;007;05;2192;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-70.056;13;1.23;1.23;1.23;1.23
+M;0003;008;05;2193;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-70.056;13;1.23;1.23;1.23;1.23
+M;0003;009;05;2194;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-57.088;13;1.23;1.23;1.23;1.23
+M;0003;010;05;2196;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-57.080;13;1.23;1.23;1.23;1.23
+M;0003;011;05;2197;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-57.080;13;1.23;1.23;1.23;1.23
+M;0003;012;05;2198;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-57.080;13;1.23;1.23;1.23;1.23
+M;0003;013;05;2199;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-57.080;13;1.23;1.23;1.23;1.23
+M;0003;014;05;2201;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-57.080;13;1.23;1.23;1.23;1.23
+M;0003;015;05;2202;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-57.080;13;1.23;1.23;1.23;1.23
+M;0003;016;05;2203;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-57.080;13;1.23;1.23;1.23;1.23
+M;0003;017;05;2205;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-44.096;13;1.23;1.23;1.23;1.23
+M;0003;018;05;2206;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0003;019;05;2207;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0003;020;05;2208;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0003;021;05;2210;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-44.096;13;1.23;1.23;1.23;1.23
+M;0003;022;05;2211;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0003;023;05;2212;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0003;024;05;2214;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0003;025;05;2215;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-31.112;13;1.23;1.23;1.23;1.23
+M;0003;026;05;2216;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-31.112;13;1.23;1.23;1.23;1.23
+M;0003;027;05;2218;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-31.112;13;1.23;1.23;1.23;1.23
+M;0003;028;05;2219;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-31.112;13;1.23;1.23;1.23;1.23
+M;0003;029;05;2220;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-31.104;13;1.23;1.23;1.23;1.23
+M;0003;030;05;2221;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-31.104;13;1.23;1.23;1.23;1.23
+M;0003;031;05;2223;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-31.104;13;1.23;1.23;1.23;1.23
+M;0003;032;05;2224;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-31.104;13;1.23;1.23;1.23;1.23
+M;0003;033;05;2225;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-18.096;13;1.23;1.23;1.23;1.23
+M;0003;034;05;2227;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0003;035;05;2228;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0003;036;05;2229;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0003;037;05;2230;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-18.096;13;1.23;1.23;1.23;1.23
+M;0003;038;05;2232;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0003;039;05;2233;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0003;040;05;2234;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0003;041;05;2236;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-5.120;13;1.23;1.23;1.23;1.23
+M;0003;042;05;2237;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-5.120;13;1.23;1.23;1.23;1.23
+M;0003;043;05;2238;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-5.120;13;1.23;1.23;1.23;1.23
+M;0003;044;05;2240;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.856;-5.120;13;1.23;1.23;1.23;1.23
+M;0003;045;05;2241;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-5.120;13;1.23;1.23;1.23;1.23
+M;0003;046;05;2242;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-5.120;13;1.23;1.23;1.23;1.23
+M;0003;047;05;2243;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-5.120;13;1.23;1.23;1.23;1.23
+M;0003;048;05;2245;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.864;-5.120;13;1.23;1.23;1.23;1.23
+P;0003;;;2245;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.864;-5.120;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2280;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2310;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2340;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2370;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2400;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2430;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2460;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2490;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2520;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2550;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2580;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2610;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2640;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2670;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0003;;;2700;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+F;0003;001;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;002;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;003;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;004;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;005;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;006;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;007;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;008;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;009;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;010;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;011;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;012;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;013;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;014;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;015;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;016;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;017;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;018;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;019;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;020;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;021;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;022;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;023;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;024;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;025;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;026;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;027;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;028;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;029;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;030;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;031;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;032;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;033;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;034;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;035;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;036;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;037;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;038;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;039;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;040;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;041;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;042;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;043;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;044;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;045;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;046;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;047;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0003;048;;2716;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+P;0004;;;2716;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;2719;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;3;;;;1.23;1.23;1.23;1.23;1.23;
+R;0004;;01;2747;1.23;1.23;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1907.59;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;30;1.23;1.23;1.23;1.23
+M;0004;001;01;2748;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;#;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.904;-70.064;32;1.23;1.23;1.23;1.23
+M;0004;002;01;2750;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0004;003;01;2751;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0004;004;01;2752;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0004;005;01;2753;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-70.064;32;1.23;1.23;1.23;1.23
+M;0004;006;01;2755;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0004;007;01;2756;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0004;008;01;2757;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-70.064;32;1.23;1.23;1.23;1.23
+M;0004;009;01;2759;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-57.088;32;1.23;1.23;1.23;1.23
+M;0004;010;01;2760;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-57.088;32;1.23;1.23;1.23;1.23
+M;0004;011;01;2761;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-57.088;32;1.23;1.23;1.23;1.23
+M;0004;012;01;2763;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-57.088;32;1.23;1.23;1.23;1.23
+M;0004;013;01;2764;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-57.088;32;1.23;1.23;1.23;1.23
+M;0004;014;01;2765;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-57.088;32;1.23;1.23;1.23;1.23
+M;0004;015;01;2766;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-57.088;32;1.23;1.23;1.23;1.23
+M;0004;016;01;2768;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-57.088;32;1.23;1.23;1.23;1.23
+M;0004;017;01;2769;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-44.096;32;1.23;1.23;1.23;1.23
+M;0004;018;01;2770;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0004;019;01;2772;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0004;020;01;2773;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0004;021;01;2774;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-44.096;32;1.23;1.23;1.23;1.23
+M;0004;022;01;2775;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0004;023;01;2777;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0004;024;01;2778;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-44.096;32;1.23;1.23;1.23;1.23
+M;0004;025;01;2779;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-31.104;32;1.23;1.23;1.23;1.23
+M;0004;026;01;2780;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-31.104;32;1.23;1.23;1.23;1.23
+M;0004;027;01;2782;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-31.104;32;1.23;1.23;1.23;1.23
+M;0004;028;01;2783;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-31.104;32;1.23;1.23;1.23;1.23
+M;0004;029;01;2784;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-31.104;32;1.23;1.23;1.23;1.23
+M;0004;030;01;2786;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-31.104;32;1.23;1.23;1.23;1.23
+M;0004;031;01;2787;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-31.104;32;1.23;1.23;1.23;1.23
+M;0004;032;01;2788;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-31.104;32;1.23;1.23;1.23;1.23
+M;0004;033;01;2790;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-18.104;32;1.23;1.23;1.23;1.23
+M;0004;034;01;2791;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-18.104;32;1.23;1.23;1.23;1.23
+M;0004;035;01;2792;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-18.096;32;1.23;1.23;1.23;1.23
+M;0004;036;01;2793;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-18.096;32;1.23;1.23;1.23;1.23
+M;0004;037;01;2795;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-18.096;32;1.23;1.23;1.23;1.23
+M;0004;038;01;2796;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-18.096;32;1.23;1.23;1.23;1.23
+M;0004;039;01;2797;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-18.096;32;1.23;1.23;1.23;1.23
+M;0004;040;01;2798;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-18.096;32;1.23;1.23;1.23;1.23
+M;0004;041;01;2800;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-5.120;32;1.23;1.23;1.23;1.23
+M;0004;042;01;2801;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-5.128;32;1.23;1.23;1.23;1.23
+M;0004;043;01;2802;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-5.120;32;1.23;1.23;1.23;1.23
+M;0004;044;01;2804;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.856;-5.120;32;1.23;1.23;1.23;1.23
+M;0004;045;01;2805;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-5.120;32;1.23;1.23;1.23;1.23
+M;0004;046;01;2806;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-5.120;32;1.23;1.23;1.23;1.23
+M;0004;047;01;2808;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-5.120;32;1.23;1.23;1.23;1.23
+M;0004;048;01;2809;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.120;32;1.23;1.23;1.23;1.23
+P;0004;;;2809;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.120;32;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;2811;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-5.120;2;;;;1.23;1.23;1.23;1.23;1.23;
+M;0004;001;02;2832;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.408;-72.552;23;1.23;1.23;1.23;1.23
+M;0004;002;02;2834;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0004;003;02;2835;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-72.552;23;1.23;1.23;1.23;1.23
+M;0004;004;02;2836;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0004;005;02;2838;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0004;006;02;2839;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.400;-72.552;23;1.23;1.23;1.23;1.23
+M;0004;007;02;2840;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-72.552;23;1.23;1.23;1.23;1.23
+M;0004;008;02;2841;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-72.552;23;1.23;1.23;1.23;1.23
+M;0004;009;02;2843;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-59.584;23;1.23;1.23;1.23;1.23
+M;0004;010;02;2844;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-59.584;23;1.23;1.23;1.23;1.23
+M;0004;011;02;2845;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-59.584;23;1.23;1.23;1.23;1.23
+M;0004;012;02;2846;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-59.584;23;1.23;1.23;1.23;1.23
+M;0004;013;02;2848;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-59.584;23;1.23;1.23;1.23;1.23
+M;0004;014;02;2849;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-59.584;23;1.23;1.23;1.23;1.23
+M;0004;015;02;2850;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-59.584;23;1.23;1.23;1.23;1.23
+M;0004;016;02;2851;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-59.584;23;1.23;1.23;1.23;1.23
+M;0004;017;02;2853;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-46.576;23;1.23;1.23;1.23;1.23
+M;0004;018;02;2854;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-46.576;23;1.23;1.23;1.23;1.23
+M;0004;019;02;2855;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-46.576;23;1.23;1.23;1.23;1.23
+M;0004;020;02;2857;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-46.576;23;1.23;1.23;1.23;1.23
+M;0004;021;02;2858;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-46.576;23;1.23;1.23;1.23;1.23
+M;0004;022;02;2859;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-46.576;23;1.23;1.23;1.23;1.23
+M;0004;023;02;2861;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.400;-46.576;23;1.23;1.23;1.23;1.23
+M;0004;024;02;2862;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-46.576;23;1.23;1.23;1.23;1.23
+M;0004;025;02;2863;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-33.600;23;1.23;1.23;1.23;1.23
+M;0004;026;02;2864;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0004;027;02;2866;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-33.600;23;1.23;1.23;1.23;1.23
+M;0004;028;02;2867;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0004;029;02;2868;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0004;030;02;2870;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0004;031;02;2871;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.352;-33.600;23;1.23;1.23;1.23;1.23
+M;0004;032;02;2872;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-33.600;23;1.23;1.23;1.23;1.23
+M;0004;033;02;2873;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-20.592;23;1.23;1.23;1.23;1.23
+M;0004;034;02;2875;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-20.592;23;1.23;1.23;1.23;1.23
+M;0004;035;02;2876;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-20.592;23;1.23;1.23;1.23;1.23
+M;0004;036;02;2877;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-20.592;23;1.23;1.23;1.23;1.23
+M;0004;037;02;2879;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-20.592;23;1.23;1.23;1.23;1.23
+M;0004;038;02;2880;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-20.592;23;1.23;1.23;1.23;1.23
+M;0004;039;02;2881;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-20.592;23;1.23;1.23;1.23;1.23
+M;0004;040;02;2882;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-20.592;23;1.23;1.23;1.23;1.23
+M;0004;041;02;2884;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-7.616;23;1.23;1.23;1.23;1.23
+M;0004;042;02;2885;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-7.616;23;1.23;1.23;1.23;1.23
+M;0004;043;02;2886;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-7.616;23;1.23;1.23;1.23;1.23
+M;0004;044;02;2887;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-7.616;23;1.23;1.23;1.23;1.23
+M;0004;045;02;2889;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-7.616;23;1.23;1.23;1.23;1.23
+M;0004;046;02;2890;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-7.616;23;1.23;1.23;1.23;1.23
+M;0004;047;02;2891;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.352;-7.616;23;1.23;1.23;1.23;1.23
+M;0004;048;02;2893;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-7.616;23;1.23;1.23;1.23;1.23
+P;0004;;;2893;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-7.616;23;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;2894;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-7.616;1;;;;1.23;1.23;1.23;1.23;1.23;
+M;0004;001;03;2916;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0004;002;03;2918;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-67.584;23;1.23;1.23;1.23;1.23
+M;0004;003;03;2919;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0004;004;03;2920;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0004;005;03;2922;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-67.584;23;1.23;1.23;1.23;1.23
+M;0004;006;03;2923;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0004;007;03;2924;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-67.584;23;1.23;1.23;1.23;1.23
+M;0004;008;03;2926;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-67.584;23;1.23;1.23;1.23;1.23
+M;0004;009;03;2927;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-54.576;23;1.23;1.23;1.23;1.23
+M;0004;010;03;2928;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0004;011;03;2929;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-54.576;23;1.23;1.23;1.23;1.23
+M;0004;012;03;2931;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0004;013;03;2932;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0004;014;03;2933;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0004;015;03;2935;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-54.576;23;1.23;1.23;1.23;1.23
+M;0004;016;03;2936;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-54.576;23;1.23;1.23;1.23;1.23
+M;0004;017;03;2937;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-41.592;23;1.23;1.23;1.23;1.23
+M;0004;018;03;2938;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-41.592;23;1.23;1.23;1.23;1.23
+M;0004;019;03;2940;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-41.592;23;1.23;1.23;1.23;1.23
+M;0004;020;03;2941;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-41.592;23;1.23;1.23;1.23;1.23
+M;0004;021;03;2942;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-41.592;23;1.23;1.23;1.23;1.23
+M;0004;022;03;2943;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-41.592;23;1.23;1.23;1.23;1.23
+M;0004;023;03;2945;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-41.592;23;1.23;1.23;1.23;1.23
+M;0004;024;03;2946;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-41.592;23;1.23;1.23;1.23;1.23
+M;0004;025;03;2947;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-28.600;23;1.23;1.23;1.23;1.23
+M;0004;026;03;2949;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0004;027;03;2950;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-28.600;23;1.23;1.23;1.23;1.23
+M;0004;028;03;2951;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0004;029;03;2953;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0004;030;03;2954;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0004;031;03;2955;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.360;-28.600;23;1.23;1.23;1.23;1.23
+M;0004;032;03;2957;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-28.600;23;1.23;1.23;1.23;1.23
+M;0004;033;03;2958;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-15.600;23;1.23;1.23;1.23;1.23
+M;0004;034;03;2959;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.392;-15.600;23;1.23;1.23;1.23;1.23
+M;0004;035;03;2960;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.400;-15.600;23;1.23;1.23;1.23;1.23
+M;0004;036;03;2962;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.400;-15.600;23;1.23;1.23;1.23;1.23
+M;0004;037;03;2963;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.392;-15.600;23;1.23;1.23;1.23;1.23
+M;0004;038;03;2964;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.408;-15.600;23;1.23;1.23;1.23;1.23
+M;0004;039;03;2965;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.392;-15.600;23;1.23;1.23;1.23;1.23
+M;0004;040;03;2967;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-15.600;23;1.23;1.23;1.23;1.23
+M;0004;041;03;2968;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-10.400;-2.624;23;1.23;1.23;1.23;1.23
+M;0004;042;03;2969;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-23.368;-2.624;23;1.23;1.23;1.23;1.23
+M;0004;043;03;2971;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-36.376;-2.624;23;1.23;1.23;1.23;1.23
+M;0004;044;03;2972;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-49.360;-2.624;23;1.23;1.23;1.23;1.23
+M;0004;045;03;2973;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-62.368;-2.624;23;1.23;1.23;1.23;1.23
+M;0004;046;03;2974;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-75.368;-2.624;23;1.23;1.23;1.23;1.23
+M;0004;047;03;2976;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-88.352;-2.624;23;1.23;1.23;1.23;1.23
+M;0004;048;03;2977;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-2.624;23;1.23;1.23;1.23;1.23
+P;0004;;;2977;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-2.624;23;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;2980;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-101.368;-2.624;3;;;;1.23;1.23;1.23;1.23;1.23;
+R;0004;;04;3009;1.23;1.23;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1904.39;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.560;32;1.23;1.23;1.23;1.23
+M;0004;001;04;3011;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;#;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.904;-70.056;33;1.23;1.23;1.23;1.23
+M;0004;002;04;3012;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-70.056;33;1.23;1.23;1.23;1.23
+M;0004;003;04;3014;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-70.056;33;1.23;1.23;1.23;1.23
+M;0004;004;04;3015;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-70.056;33;1.23;1.23;1.23;1.23
+M;0004;005;04;3016;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-70.056;33;1.23;1.23;1.23;1.23
+M;0004;006;04;3018;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-70.056;33;1.23;1.23;1.23;1.23
+M;0004;007;04;3019;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.888;-70.056;33;1.23;1.23;1.23;1.23
+M;0004;008;04;3020;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-70.056;33;1.23;1.23;1.23;1.23
+M;0004;009;04;3021;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-57.088;33;1.23;1.23;1.23;1.23
+M;0004;010;04;3023;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-57.088;33;1.23;1.23;1.23;1.23
+M;0004;011;04;3024;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-57.088;33;1.23;1.23;1.23;1.23
+M;0004;012;04;3025;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-57.088;33;1.23;1.23;1.23;1.23
+M;0004;013;04;3027;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-57.088;33;1.23;1.23;1.23;1.23
+M;0004;014;04;3028;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-57.088;33;1.23;1.23;1.23;1.23
+M;0004;015;04;3029;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-57.080;33;1.23;1.23;1.23;1.23
+M;0004;016;04;3030;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-57.080;33;1.23;1.23;1.23;1.23
+M;0004;017;04;3032;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-44.096;33;1.23;1.23;1.23;1.23
+M;0004;018;04;3033;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0004;019;04;3034;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0004;020;04;3036;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0004;021;04;3037;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-44.096;33;1.23;1.23;1.23;1.23
+M;0004;022;04;3038;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0004;023;04;3040;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0004;024;04;3041;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-44.096;33;1.23;1.23;1.23;1.23
+M;0004;025;04;3042;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-31.104;33;1.23;1.23;1.23;1.23
+M;0004;026;04;3043;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0004;027;04;3045;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-31.104;33;1.23;1.23;1.23;1.23
+M;0004;028;04;3046;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0004;029;04;3047;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-31.104;33;1.23;1.23;1.23;1.23
+M;0004;030;04;3048;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0004;031;04;3050;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-31.104;33;1.23;1.23;1.23;1.23
+M;0004;032;04;3051;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-31.104;33;1.23;1.23;1.23;1.23
+M;0004;033;04;3052;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-18.104;33;1.23;1.23;1.23;1.23
+M;0004;034;04;3053;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0004;035;04;3055;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0004;036;04;3056;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0004;037;04;3057;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-18.104;33;1.23;1.23;1.23;1.23
+M;0004;038;04;3059;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0004;039;04;3060;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-18.104;33;1.23;1.23;1.23;1.23
+M;0004;040;04;3061;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-18.096;33;1.23;1.23;1.23;1.23
+M;0004;041;04;3063;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-5.128;33;1.23;1.23;1.23;1.23
+M;0004;042;04;3064;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-5.128;33;1.23;1.23;1.23;1.23
+M;0004;043;04;3065;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-5.128;33;1.23;1.23;1.23;1.23
+M;0004;044;04;3067;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-5.128;33;1.23;1.23;1.23;1.23
+M;0004;045;04;3068;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-5.120;33;1.23;1.23;1.23;1.23
+M;0004;046;04;3069;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-5.120;33;1.23;1.23;1.23;1.23
+M;0004;047;04;3070;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.856;-5.120;33;1.23;1.23;1.23;1.23
+M;0004;048;04;3072;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.864;-5.120;33;1.23;1.23;1.23;1.23
+P;0004;;;3072;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.864;-5.120;33;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3075;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.864;-5.120;3;;;;1.23;1.23;1.23;1.23;1.23;
+R;0004;;05;3084;1.23;1.23;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1995.61;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;12;1.23;1.23;1.23;1.23
+M;0004;001;05;3086;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;#;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.904;-70.064;13;1.23;1.23;1.23;1.23
+M;0004;002;05;3087;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0004;003;05;3089;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0004;004;05;3090;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0004;005;05;3091;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-70.064;13;1.23;1.23;1.23;1.23
+M;0004;006;05;3092;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0004;007;05;3094;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.888;-70.064;13;1.23;1.23;1.23;1.23
+M;0004;008;05;3095;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-70.064;13;1.23;1.23;1.23;1.23
+M;0004;009;05;3096;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.888;-57.088;13;1.23;1.23;1.23;1.23
+M;0004;010;05;3097;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-57.080;13;1.23;1.23;1.23;1.23
+M;0004;011;05;3099;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-57.080;13;1.23;1.23;1.23;1.23
+M;0004;012;05;3100;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.856;-57.080;13;1.23;1.23;1.23;1.23
+M;0004;013;05;3101;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-57.080;13;1.23;1.23;1.23;1.23
+M;0004;014;05;3103;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-57.080;13;1.23;1.23;1.23;1.23
+M;0004;015;05;3104;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-57.080;13;1.23;1.23;1.23;1.23
+M;0004;016;05;3105;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-57.080;13;1.23;1.23;1.23;1.23
+M;0004;017;05;3106;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-44.096;13;1.23;1.23;1.23;1.23
+M;0004;018;05;3108;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0004;019;05;3109;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0004;020;05;3110;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0004;021;05;3112;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-44.096;13;1.23;1.23;1.23;1.23
+M;0004;022;05;3113;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0004;023;05;3114;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0004;024;05;3115;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-44.096;13;1.23;1.23;1.23;1.23
+M;0004;025;05;3117;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-31.104;13;1.23;1.23;1.23;1.23
+M;0004;026;05;3118;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-31.104;13;1.23;1.23;1.23;1.23
+M;0004;027;05;3119;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-31.104;13;1.23;1.23;1.23;1.23
+M;0004;028;05;3120;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-31.104;13;1.23;1.23;1.23;1.23
+M;0004;029;05;3122;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-31.104;13;1.23;1.23;1.23;1.23
+M;0004;030;05;3123;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-31.104;13;1.23;1.23;1.23;1.23
+M;0004;031;05;3124;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-31.104;13;1.23;1.23;1.23;1.23
+M;0004;032;05;3126;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-31.104;13;1.23;1.23;1.23;1.23
+M;0004;033;05;3127;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.872;-18.104;13;1.23;1.23;1.23;1.23
+M;0004;034;05;3128;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.896;-18.104;13;1.23;1.23;1.23;1.23
+M;0004;035;05;3129;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0004;036;05;3131;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0004;037;05;3132;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.888;-18.096;13;1.23;1.23;1.23;1.23
+M;0004;038;05;3133;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0004;039;05;3135;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0004;040;05;3136;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-18.096;13;1.23;1.23;1.23;1.23
+M;0004;041;05;3137;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-12.896;-5.120;13;1.23;1.23;1.23;1.23
+M;0004;042;05;3139;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-25.864;-5.120;13;1.23;1.23;1.23;1.23
+M;0004;043;05;3140;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-38.872;-5.120;13;1.23;1.23;1.23;1.23
+M;0004;044;05;3141;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-51.864;-5.120;13;1.23;1.23;1.23;1.23
+M;0004;045;05;3143;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-64.872;-5.120;13;1.23;1.23;1.23;1.23
+M;0004;046;05;3144;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-77.864;-5.120;13;1.23;1.23;1.23;1.23
+M;0004;047;05;3145;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-90.864;-5.120;13;1.23;1.23;1.23;1.23
+M;0004;048;05;3146;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.864;-5.120;13;1.23;1.23;1.23;1.23
+P;0004;;;3146;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-103.864;-5.120;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3181;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3211;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3241;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3271;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3301;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3331;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3361;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3391;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3421;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3451;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3481;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3511;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3541;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3571;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+P;0004;;;3601;;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;;;;;;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;1.23;-125.848;-69.552;13;;;;1.23;1.23;1.23;1.23;1.23;
+F;0004;001;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;002;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;003;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;004;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;005;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;006;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;007;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;008;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;009;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;010;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;011;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;012;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;013;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;014;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;015;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;016;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;017;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;018;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;019;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;020;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;021;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;022;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;023;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;024;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;025;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;026;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;027;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;028;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;029;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;030;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;031;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;032;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;033;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;034;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;035;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;036;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;037;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;038;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;039;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;040;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;041;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;042;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;043;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;044;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;045;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;046;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;047;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+F;0004;048;;3616;;;;;;;;;;;;;;;;;-1;0.000;1.23;1.23
+=====end_process=====
+[end_date_time] 2024-01-01, 13:00:00


### PR DESCRIPTION
* Biomass filters with ID 401 were previously unknown
* Fluidics data in 48-well mode caused parsing errors

Closes #70