### PR TITLE
Fix bug with `find_do_peak(delay_b)` kwarg

### DIFF
--- a/bletl/__init__.py
+++ b/bletl/__init__.py
@@ -36,4 +36,4 @@ from .types import (
     NoMeasurementData,
 )
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/bletl/heuristics.py
+++ b/bletl/heuristics.py
@@ -75,4 +75,10 @@ def find_do_peak(
                 if overshot_since >= delay_b:
                     # the DO has remained above the threshold for long enough
                     break
-    return i_overshot
+
+    # Did the series continue long enough after reaching the threshold?
+    if i_overshot is not None:
+        overshot_since = x[i_total - 1] - x[i_overshot]
+        if overshot_since >= delay_b:
+            return i_overshot
+    return None

--- a/tests/test_heuristics.py
+++ b/tests/test_heuristics.py
@@ -18,3 +18,42 @@ class TestDOPeakDetection:
 
         assert c_peak == 60
         return
+
+    def test_find_no_peak_with_long_delay_a(self):
+        bldata = bletl.parse(FP_TESTFILE)
+
+        x, y = bldata["DO"].get_timeseries("A01")
+
+        # The DO was below 70 for only ~2 h
+        c_peak = bletl.find_do_peak(
+            x, y, delay_a=5, threshold_a=70, delay_b=0, threshold_b=80, initial_delay=1
+        )
+
+        assert c_peak is None
+        return
+
+    def test_find_no_peak_with_long_delay_b(self):
+        bldata = bletl.parse(FP_TESTFILE)
+
+        x, y = bldata["DO"].get_timeseries("A01")
+
+        # The series continues for only ~9.5 h after the peak
+        c_peak = bletl.find_do_peak(
+            x, y, delay_a=0.5, threshold_a=70, delay_b=12, threshold_b=80, initial_delay=1
+        )
+
+        assert c_peak is None
+        return
+
+    def test_find_no_peak_with_long_initial_delay(self):
+        bldata = bletl.parse(FP_TESTFILE)
+
+        x, y = bldata["DO"].get_timeseries("A01")
+
+        # The peak is within the first ~12 h
+        c_peak = bletl.find_do_peak(
+            x, y, delay_a=0.5, threshold_a=70, delay_b=4, threshold_b=80, initial_delay=15
+        )
+
+        assert c_peak is None
+        return


### PR DESCRIPTION
Using the DO peak detection the delay_b for the DO overshoot was not fulfilled. Tests checking for the initial_delay, delay_a and delay_b were implemented. The i_overshoot was returned even if the set time of delay_b had not proceeded leading to the detection of the DO peak. To fix this, a second if clause needed to be implemented checking for the fulfillment of the proceeded time being larger than the delay_b and only then returning and detecting the correspondive DO peak.