### PR TITLE
Add nutpie support

### DIFF
--- a/bletl/growth.py
+++ b/bletl/growth.py
@@ -3,6 +3,7 @@ from typing import Dict, Optional, Sequence, Tuple, Union
 
 import arviz
 import calibr8
+import importlib
 import numpy
 import pymc as pm
 import pytensor.tensor as pt
@@ -131,14 +132,25 @@ class GrowthRateResult:
         **sample_kwargs
             optional keyword-arguments to pymc.sample(...) to override defaults
         """
-        sample_kwargs = dict(
-            return_inferencedata=True,
-            target_accept=0.95,
-            init="adapt_diag",
-            initvals=self.theta_map,
-            tune=500,
-            draws=500,
-        )
+        if importlib.util.find_spec("nutpie"):
+            sample_kwargs = dict(
+                return_inferencedata=True,
+                target_accept=0.95,
+                nuts_sampler="nutpie",
+                init="adapt_diag",
+                init_means=self.theta_map,
+                tune=500,
+                draws=500,
+            )
+        else:
+            sample_kwargs = dict(
+                return_inferencedata=True,
+                target_accept=0.95,
+                init="adapt_diag",
+                initvals=self.theta_map,
+                tune=500,
+                draws=500,
+            )
         sample_kwargs.update(kwargs)
         with self.pmodel:
             self._idata = pm.sample(**sample_kwargs)


### PR DESCRIPTION
More recent `nutpie` versions take initial values via the `init_means` argument (as opposed to `initvals` with the default sampler). Accordingly, `nutpie` can now be employed for faster sampling.