### PR TITLE
Add BL1 process parameters to metadata and setpoints to environment

### DIFF
--- a/bletl/parsing/bl1.py
+++ b/bletl/parsing/bl1.py
@@ -199,10 +199,14 @@ class BioLector1Parser(BLDParser):
         references = extract_references(data)
         comments = extract_comments(data, references)
         measurements = extract_measurements(data)
+        environment = extract_environment(data, process_parameters, comments)
+        # Also put process parameters into the metadata
+        for k, v in process_parameters.items():
+            metadata[f"process_parameter_{k}"] = v
 
         data = BLData(
             model=BioLectorModel.BL1,
-            environment=extract_environment(data, process_parameters, comments),
+            environment=environment,
             filtersets=filtersets,
             references=references,
             measurements=measurements,
@@ -454,6 +458,9 @@ def extract_environment(dfraw, process_parameters: dict, comments: pandas.DataFr
     df = utils.__to_typed_cols__(dfraw, ocol_ncol_type)
     df["shaker_setpoint"] = process_parameters["shaking"]
     df["temp_setpoint"] = process_parameters["temperature"]
+    df["humidity_setpoint"] = process_parameters["humidity"]
+    df["O2_setpoint"] = process_parameters["O2"]
+    df["CO2_setpoint"] = process_parameters["CO2"]
     # process the comments column to extract setpoint changes
     for t_comment, cmts in zip(comments["time"], comments["user_comment"]):
         # multiple comments may be ,-separated in one line

--- a/bletl/parsing/blpro.py
+++ b/bletl/parsing/blpro.py
@@ -73,7 +73,7 @@ class BioLectorProParser(BLDParser):
 
         bld = BLData(
             model=BioLectorModel.BLPro,
-            environment=extract_environment(data),
+            environment=extract_environment(data, metadata),
             filtersets=extract_filtersets(metadata),
             references=extract_references(data),
             measurements=extract_measurements(data),
@@ -353,7 +353,7 @@ def extract_measurements(dfraw):
     return standardize(df)
 
 
-def extract_environment(dfraw):
+def extract_environment(dfraw, metadata):
     ocol_ncol_type = [
         ("Cycle", "cycle", int),
         ("Time", "time", float),
@@ -368,8 +368,11 @@ def extract_environment(dfraw):
         ("Shaker", "shaker_actual", float),
     ]
     df = utils.__to_typed_cols__(dfraw[dfraw["Type"] == "R"], ocol_ncol_type)
-    # TODO: write initial setpoints (temp & shaker) into df
-    # TODO: parse setpoint changes (temp & shaker) from comments
+    # Write initial setpoints (temp & shaker) into df
+    df["humidity_setpoint"] = float(metadata["process"]["humidity"])
+    df["O2_setpoint"] = float(metadata["process"]["o2"])
+    df["CO2_setpoint"] = float(metadata["process"]["co2"])
+    # TODO: parse setpoint changes (temp & shaker) from profiles in the metadata
     # TODO: clean up -9999.0 values in co2 column
     return standardize(df)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "bletl"
-version = "1.5.4"
+version = "1.6.0"
 description = "Package for parsing and transforming BioLector raw data."
 readme = "README.md"
 requires-python = ">=3.8"


### PR DESCRIPTION
⚠ Profiles are NOT parsed from BioLector II/Pro data.

Use the new `environment` columns with caution.